### PR TITLE
feat(analytics): Implement Order Analytics Dashboard — aggregation endpoint, Recharts charts, admin-only access (Closes #38)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -34,6 +34,7 @@
         "react-silk": "^0.0.1",
         "react-slick": "^0.30.3",
         "react-toastify": "^11.0.3",
+        "recharts": "^2.15.4",
         "slick-carousel": "^1.8.1",
         "swiper": "^11.2.2",
         "tailwindcss": "^4.0.0",
@@ -96,6 +97,7 @@
       "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -414,6 +416,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -457,6 +460,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1223,6 +1227,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.1.tgz",
       "integrity": "sha512-MFBfia6UiKxyoLeGkAh8M15bkeDmfnsUTMRJd/vTQue6YQ8AQ6lw9HqDthyYghzDEWIvZO/lQQzLrZE8XwNJLA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.4.1",
@@ -1980,6 +1985,69 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2010,6 +2078,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2066,6 +2135,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2375,6 +2445,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2606,6 +2677,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -2686,6 +2878,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3062,6 +3260,7 @@
       "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3266,12 +3465,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3771,6 +3985,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5086,6 +5309,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5098,6 +5322,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5147,6 +5372,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5266,6 +5492,21 @@
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-toastify": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.3.tgz",
@@ -5295,11 +5536,51 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5871,6 +6152,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6071,11 +6358,34 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
       "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.24.2",
         "postcss": "^8.4.49",

--- a/client/package.json
+++ b/client/package.json
@@ -36,6 +36,7 @@
     "react-silk": "^0.0.1",
     "react-slick": "^0.30.3",
     "react-toastify": "^11.0.3",
+    "recharts": "^2.15.4",
     "slick-carousel": "^1.8.1",
     "swiper": "^11.2.2",
     "tailwindcss": "^4.0.0",

--- a/client/src/pages/admin/AdminAnalytics.jsx
+++ b/client/src/pages/admin/AdminAnalytics.jsx
@@ -1,0 +1,449 @@
+import { useEffect, useState, useMemo } from "react";
+import PropTypes from "prop-types";
+import { useDispatch, useSelector } from "react-redux";
+import { CircularProgress } from "@mui/material";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  AreaChart,
+  Area,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as ReTooltip,
+  Legend,
+} from "recharts";
+import {
+  IndianRupee,
+  ShoppingCart,
+  Package,
+  TrendingUp,
+  RefreshCw,
+} from "lucide-react";
+import { getOrderAnalytics } from "@/store/order-slice/analyticsSlice";
+import MetaData from "../extras/MetaData";
+
+// Palette for the status pie / bars (kept small and readable on dark + light).
+const STATUS_COLORS = {
+  PENDING: "#f59e0b",
+  SHIPPED: "#3b82f6",
+  DELIVERED: "#10b981",
+  CANCELLED: "#ef4444",
+  UNKNOWN: "#9ca3af",
+};
+const PIE_FALLBACK = ["#6366f1", "#8b5cf6", "#ec4899", "#14b8a6", "#f97316"];
+
+const formatCurrency = (value) => {
+  const n = Number(value) || 0;
+  return new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency: "INR",
+    maximumFractionDigits: 0,
+  }).format(n);
+};
+
+const formatNumber = (value) =>
+  new Intl.NumberFormat("en-IN").format(Number(value) || 0);
+
+// Reusable summary card.
+const StatCard = ({ icon: Icon, label, value, accent }) => (
+  <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-4 flex items-center gap-4">
+    <div
+      className={`shrink-0 w-12 h-12 rounded-lg flex items-center justify-center ${accent}`}
+    >
+      <Icon className="w-6 h-6 text-white" />
+    </div>
+    <div className="min-w-0">
+      <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 truncate">
+        {label}
+      </p>
+      <p className="text-lg sm:text-xl font-bold text-gray-900 dark:text-white truncate">
+        {value}
+      </p>
+    </div>
+  </div>
+);
+
+StatCard.propTypes = {
+  icon: PropTypes.elementType.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  accent: PropTypes.string.isRequired,
+};
+
+// Reusable chart frame with title + graceful empty state.
+const ChartCard = ({ title, subtitle, isEmpty, emptyText, children }) => (
+  <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-4">
+    <div className="mb-3">
+      <h3 className="text-sm sm:text-base font-semibold text-gray-800 dark:text-gray-100">
+        {title}
+      </h3>
+      {subtitle ? (
+        <p className="text-xs text-gray-500 dark:text-gray-400">{subtitle}</p>
+      ) : null}
+    </div>
+    {isEmpty ? (
+      <div className="h-[260px] flex items-center justify-center text-center text-gray-400 dark:text-gray-500 text-sm">
+        {emptyText}
+      </div>
+    ) : (
+      <div className="h-[260px] w-full">{children}</div>
+    )}
+  </div>
+);
+
+ChartCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
+  isEmpty: PropTypes.bool,
+  emptyText: PropTypes.string,
+  children: PropTypes.node,
+};
+
+const AdminAnalytics = () => {
+  const dispatch = useDispatch();
+  const { analytics, loading, error } = useSelector(
+    (state) => state.adminAnalytics
+  );
+
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [interval, setIntervalValue] = useState("day");
+
+  useEffect(() => {
+    dispatch(getOrderAnalytics({ interval }));
+    // initial load only; subsequent loads happen via Apply / interval change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch]);
+
+  const handleApply = () => {
+    dispatch(getOrderAnalytics({ startDate, endDate, interval }));
+  };
+
+  const handleReset = () => {
+    setStartDate("");
+    setEndDate("");
+    setIntervalValue("day");
+    dispatch(getOrderAnalytics({ interval: "day" }));
+  };
+
+  const handleIntervalChange = (next) => {
+    setIntervalValue(next);
+    dispatch(getOrderAnalytics({ startDate, endDate, interval: next }));
+  };
+
+  const summary = analytics?.summary;
+  const revenueTrend = useMemo(
+    () => analytics?.revenueTrend || [],
+    [analytics]
+  );
+  const orderGrowth = useMemo(() => analytics?.orderGrowth || [], [analytics]);
+  const topProducts = useMemo(() => analytics?.topProducts || [], [analytics]);
+  const statusDistribution = useMemo(
+    () => analytics?.statusDistribution || [],
+    [analytics]
+  );
+
+  const hasAnyData =
+    (summary?.totalOrders || 0) > 0 ||
+    revenueTrend.length > 0 ||
+    orderGrowth.length > 0 ||
+    topProducts.length > 0;
+
+  return (
+    <div className="space-y-4">
+      <MetaData
+        title="Order Analytics - Admin | Faith & Fast"
+        description="Sales, revenue trends, top-selling products and order growth analytics for administrators."
+        keywords="admin, analytics, sales, revenue, orders, dashboard"
+      />
+
+      {/* Header + date-range controls */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-4">
+        <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
+          <div>
+            <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+              Order Analytics
+            </h1>
+            <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+              Sales performance, revenue trends, top products and order growth.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="flex flex-col">
+              <label className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                From
+              </label>
+              <input
+                type="date"
+                value={startDate}
+                max={endDate || undefined}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="px-2 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-gray-100"
+              />
+            </div>
+            <div className="flex flex-col">
+              <label className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                To
+              </label>
+              <input
+                type="date"
+                value={endDate}
+                min={startDate || undefined}
+                onChange={(e) => setEndDate(e.target.value)}
+                className="px-2 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-gray-100"
+              />
+            </div>
+            <div className="flex flex-col">
+              <label className="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                Group by
+              </label>
+              <select
+                value={interval}
+                onChange={(e) => handleIntervalChange(e.target.value)}
+                className="px-2 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-gray-100"
+              >
+                <option value="day">Day</option>
+                <option value="month">Month</option>
+              </select>
+            </div>
+            <button
+              onClick={handleApply}
+              className="px-3 py-1.5 rounded-md bg-yellow-400 hover:bg-yellow-500 dark:bg-red-600 dark:hover:bg-red-700 text-sm font-medium text-gray-900 dark:text-white"
+            >
+              Apply
+            </button>
+            <button
+              onClick={handleReset}
+              className="px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 text-sm font-medium text-gray-700 dark:text-gray-200 flex items-center gap-1"
+            >
+              <RefreshCw className="w-4 h-4" />
+              Reset
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Loading / error / empty / content */}
+      {loading ? (
+        <div className="flex justify-center py-20">
+          <CircularProgress />
+        </div>
+      ) : error ? (
+        <p className="text-center text-red-500 py-16 text-sm sm:text-base">
+          {error}
+        </p>
+      ) : !hasAnyData ? (
+        <div className="text-center text-gray-500 dark:text-gray-400 py-16 text-sm sm:text-base">
+          No order data available for the selected range yet. Once orders start
+          coming in, your analytics will appear here.
+        </div>
+      ) : (
+        <>
+          {/* Summary cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+            <StatCard
+              icon={IndianRupee}
+              label="Total Sales"
+              value={formatCurrency(summary?.totalRevenue)}
+              accent="bg-emerald-500"
+            />
+            <StatCard
+              icon={ShoppingCart}
+              label="Total Orders"
+              value={formatNumber(summary?.totalOrders)}
+              accent="bg-blue-500"
+            />
+            <StatCard
+              icon={TrendingUp}
+              label="Avg Order Value"
+              value={formatCurrency(summary?.averageOrderValue)}
+              accent="bg-purple-500"
+            />
+            <StatCard
+              icon={Package}
+              label="Units Sold"
+              value={formatNumber(summary?.totalUnits)}
+              accent="bg-amber-500"
+            />
+          </div>
+
+          {/* Charts grid */}
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+            {/* Revenue trend */}
+            <ChartCard
+              title="Revenue Trend"
+              subtitle="Sales over time (excludes cancelled orders)"
+              isEmpty={revenueTrend.length === 0}
+              emptyText="No revenue in this range."
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart
+                  data={revenueTrend}
+                  margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb33" />
+                  <XAxis
+                    dataKey="period"
+                    tick={{ fontSize: 11 }}
+                    stroke="#9ca3af"
+                  />
+                  <YAxis tick={{ fontSize: 11 }} stroke="#9ca3af" width={48} />
+                  <ReTooltip
+                    formatter={(value) => formatCurrency(value)}
+                    contentStyle={{ fontSize: 12 }}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="revenue"
+                    name="Revenue"
+                    stroke="#10b981"
+                    strokeWidth={2}
+                    dot={false}
+                    activeDot={{ r: 4 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </ChartCard>
+
+            {/* Order growth */}
+            <ChartCard
+              title="Order Growth"
+              subtitle="Order volume over time (all orders)"
+              isEmpty={orderGrowth.length === 0}
+              emptyText="No orders in this range."
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart
+                  data={orderGrowth}
+                  margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+                >
+                  <defs>
+                    <linearGradient id="orderGrad" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.6} />
+                      <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb33" />
+                  <XAxis
+                    dataKey="period"
+                    tick={{ fontSize: 11 }}
+                    stroke="#9ca3af"
+                  />
+                  <YAxis
+                    tick={{ fontSize: 11 }}
+                    stroke="#9ca3af"
+                    width={36}
+                    allowDecimals={false}
+                  />
+                  <ReTooltip contentStyle={{ fontSize: 12 }} />
+                  <Area
+                    type="monotone"
+                    dataKey="orders"
+                    name="Orders"
+                    stroke="#3b82f6"
+                    strokeWidth={2}
+                    fill="url(#orderGrad)"
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </ChartCard>
+
+            {/* Top products */}
+            <ChartCard
+              title="Top-Selling Products"
+              subtitle="By units sold (top 5)"
+              isEmpty={topProducts.length === 0}
+              emptyText="No product sales yet."
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={topProducts}
+                  layout="vertical"
+                  margin={{ top: 8, right: 16, left: 8, bottom: 0 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb33" />
+                  <XAxis
+                    type="number"
+                    tick={{ fontSize: 11 }}
+                    stroke="#9ca3af"
+                    allowDecimals={false}
+                  />
+                  <YAxis
+                    type="category"
+                    dataKey="name"
+                    tick={{ fontSize: 11 }}
+                    stroke="#9ca3af"
+                    width={110}
+                  />
+                  <ReTooltip
+                    formatter={(value, key) =>
+                      key === "revenue"
+                        ? formatCurrency(value)
+                        : formatNumber(value)
+                    }
+                    contentStyle={{ fontSize: 12 }}
+                  />
+                  <Bar
+                    dataKey="unitsSold"
+                    name="Units sold"
+                    fill="#8b5cf6"
+                    radius={[0, 4, 4, 0]}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </ChartCard>
+
+            {/* Status distribution */}
+            <ChartCard
+              title="Order Status Distribution"
+              subtitle="Share of orders by status"
+              isEmpty={statusDistribution.length === 0}
+              emptyText="No orders in this range."
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie
+                    data={statusDistribution}
+                    dataKey="count"
+                    nameKey="status"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={90}
+                    label={(entry) => `${entry.status}: ${entry.count}`}
+                    labelLine={false}
+                    fontSize={11}
+                  >
+                    {statusDistribution.map((entry, index) => (
+                      <Cell
+                        key={entry.status}
+                        fill={
+                          STATUS_COLORS[entry.status] ||
+                          PIE_FALLBACK[index % PIE_FALLBACK.length]
+                        }
+                      />
+                    ))}
+                  </Pie>
+                  <ReTooltip
+                    formatter={(value) => formatNumber(value)}
+                    contentStyle={{ fontSize: 12 }}
+                  />
+                  <Legend wrapperStyle={{ fontSize: 12 }} />
+                </PieChart>
+              </ResponsiveContainer>
+            </ChartCard>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default AdminAnalytics;

--- a/client/src/pages/admin/AdminDashboard.jsx
+++ b/client/src/pages/admin/AdminDashboard.jsx
@@ -6,6 +6,7 @@ import {
   Package,
   Menu,
   X,
+  BarChart3,
 } from "lucide-react";
 import AdminUsers from "./AdminUsers";
 import { useNavigate } from "react-router-dom";
@@ -13,6 +14,7 @@ import AdminProducts from "./AdminProducts";
 import { useSelector } from "react-redux";
 import { motion } from "framer-motion";
 import AdminOrdersPage from "./AdminOrdersPage";
+import AdminAnalytics from "./AdminAnalytics";
 
 const AdminDashboard = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
@@ -46,6 +48,8 @@ const AdminDashboard = () => {
         return <AdminProducts />;
       case "Orders":
         return <AdminOrdersPage />;
+      case "Analytics":
+        return <AdminAnalytics />;
 
       default:
         return null;
@@ -73,6 +77,7 @@ const AdminDashboard = () => {
             { icon: Users, text: "Customers", path: "/admin/users" },
             { icon: ShoppingBag, text: "Products" },
             { icon: Package, text: "Orders" },
+            { icon: BarChart3, text: "Analytics" },
           ].map((item) => (
             <button
               key={item.text}

--- a/client/src/store/order-slice/analyticsSlice.js
+++ b/client/src/store/order-slice/analyticsSlice.js
@@ -1,0 +1,61 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import axiosInstance from "@/api";
+
+export const getOrderAnalytics = createAsyncThunk(
+  "adminAnalytics/getOrderAnalytics",
+  async (params = {}, { rejectWithValue }) => {
+    try {
+      const token = localStorage.getItem("token");
+      const { startDate, endDate, interval } = params;
+
+      const query = {};
+      if (startDate) query.startDate = startDate;
+      if (endDate) query.endDate = endDate;
+      if (interval) query.interval = interval;
+
+      const response = await axiosInstance.get("/api/order/admin/analytics", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        params: query,
+        withCredentials: true,
+      });
+      return response.data.analytics;
+    } catch (error) {
+      return rejectWithValue(error.response?.data?.message || error.message);
+    }
+  }
+);
+
+const adminAnalyticsSlice = createSlice({
+  name: "adminAnalytics",
+  initialState: {
+    analytics: null,
+    loading: false,
+    error: null,
+  },
+  reducers: {
+    clearAnalytics: (state) => {
+      state.analytics = null;
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(getOrderAnalytics.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(getOrderAnalytics.fulfilled, (state, action) => {
+        state.loading = false;
+        state.analytics = action.payload;
+      })
+      .addCase(getOrderAnalytics.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      });
+  },
+});
+
+export const { clearAnalytics } = adminAnalyticsSlice.actions;
+export default adminAnalyticsSlice.reducer;

--- a/client/src/store/store.js
+++ b/client/src/store/store.js
@@ -13,6 +13,7 @@ import orderReducer from "./order-slice/order";
 import discountReducer from "./extra-slice/discount";
 import onlineReducer from "./order-slice/order";
 import adminOrdersReducer from "./order-slice/AdminOrderSlice";
+import adminAnalyticsReducer from "./order-slice/analyticsSlice";
 
 const store = configureStore({
   reducer: {
@@ -29,7 +30,8 @@ const store = configureStore({
     order: orderReducer,
     discount: discountReducer,
     online: onlineReducer,
-    adminOrders: adminOrdersReducer
+    adminOrders: adminOrdersReducer,
+    adminAnalytics: adminAnalyticsReducer,
   },
 });
 

--- a/server/controllers/analyticsController.js
+++ b/server/controllers/analyticsController.js
@@ -1,0 +1,242 @@
+import catchAsyncErrors from "../middleware/catchAsyncErrors.js";
+import OrderModel from "../models/orderModel.js";
+
+/**
+ * Order Analytics (Admin)
+ *
+ * All metrics are computed inside MongoDB via aggregation pipelines — no order
+ * documents are pulled into Node and reduced in memory. This keeps the endpoint
+ * fast and scalable as the order collection grows.
+ *
+ * Optional query params:
+ *   startDate  ISO date string (inclusive)  — filters createdAt >= startDate
+ *   endDate    ISO date string (inclusive)  — filters createdAt <= endDate (end of day)
+ *   interval   "day" | "month"  (default "day") — bucket size for the time series
+ *
+ * Revenue convention:
+ *   "Revenue" / "Sales" sums `totalAmount` over orders whose orderStatus is NOT
+ *   CANCELLED, because a cancelled order represents no realized sale. Order-growth
+ *   counts every order (including cancelled) so the two series stay distinct and
+ *   each answers its own question.
+ */
+export const getOrderAnalytics = catchAsyncErrors(async (req, res) => {
+  try {
+    const { startDate, endDate } = req.query;
+    const interval = req.query.interval === "month" ? "month" : "day";
+
+    // ----- Build an optional createdAt date filter -----
+    const dateFilter = {};
+    if (startDate) {
+      const from = new Date(startDate);
+      if (!isNaN(from.getTime())) {
+        dateFilter.$gte = from;
+      }
+    }
+    if (endDate) {
+      const to = new Date(endDate);
+      if (!isNaN(to.getTime())) {
+        // include the entire end day
+        to.setHours(23, 59, 59, 999);
+        dateFilter.$lte = to;
+      }
+    }
+    const hasDateFilter = Object.keys(dateFilter).length > 0;
+
+    // Base match applied to every pipeline (date window only).
+    const baseMatch = hasDateFilter ? { createdAt: dateFilter } : {};
+
+    // Money math excludes cancelled orders.
+    const revenueMatch = { ...baseMatch, orderStatus: { $ne: "CANCELLED" } };
+
+    // Date-bucket format string for $dateToString.
+    const dateFormat = interval === "month" ? "%Y-%m" : "%Y-%m-%d";
+
+    // ----- 1. Summary (single-doc rollup via $facet) -----
+    const summaryPipeline = [
+      { $match: baseMatch },
+      {
+        $facet: {
+          // Revenue + units over non-cancelled orders.
+          revenue: [
+            { $match: { orderStatus: { $ne: "CANCELLED" } } },
+            {
+              $group: {
+                _id: null,
+                totalRevenue: { $sum: "$totalAmount" },
+                paidOrders: { $sum: 1 },
+              },
+            },
+          ],
+          // Units sold (sum of quantities) over non-cancelled orders.
+          units: [
+            { $match: { orderStatus: { $ne: "CANCELLED" } } },
+            { $unwind: "$products" },
+            {
+              $group: {
+                _id: null,
+                totalUnits: { $sum: "$products.quantity" },
+              },
+            },
+          ],
+          // Count of every order in range (incl cancelled).
+          allOrders: [{ $count: "count" }],
+          // Order status breakdown.
+          byStatus: [
+            { $group: { _id: "$orderStatus", count: { $sum: 1 } } },
+          ],
+          // Payment status breakdown.
+          byPayment: [
+            { $group: { _id: "$paymentStatus", count: { $sum: 1 } } },
+          ],
+        },
+      },
+    ];
+
+    // ----- 2. Revenue trend (time series, non-cancelled) -----
+    const revenueTrendPipeline = [
+      { $match: revenueMatch },
+      {
+        $group: {
+          _id: {
+            $dateToString: { format: dateFormat, date: "$createdAt" },
+          },
+          revenue: { $sum: "$totalAmount" },
+          orders: { $sum: 1 },
+        },
+      },
+      { $sort: { _id: 1 } },
+      {
+        $project: {
+          _id: 0,
+          period: "$_id",
+          revenue: 1,
+          orders: 1,
+        },
+      },
+    ];
+
+    // ----- 3. Order growth (time series, ALL orders) -----
+    const orderGrowthPipeline = [
+      { $match: baseMatch },
+      {
+        $group: {
+          _id: {
+            $dateToString: { format: dateFormat, date: "$createdAt" },
+          },
+          orders: { $sum: 1 },
+        },
+      },
+      { $sort: { _id: 1 } },
+      {
+        $project: {
+          _id: 0,
+          period: "$_id",
+          orders: 1,
+        },
+      },
+    ];
+
+    // ----- 4. Top-selling products (non-cancelled) -----
+    const topProductsPipeline = [
+      { $match: revenueMatch },
+      { $unwind: "$products" },
+      {
+        $group: {
+          _id: "$products.product",
+          unitsSold: { $sum: "$products.quantity" },
+          revenue: {
+            $sum: {
+              $multiply: [
+                { $ifNull: ["$products.quantity", 0] },
+                { $ifNull: ["$products.price", 0] },
+              ],
+            },
+          },
+        },
+      },
+      { $sort: { unitsSold: -1, revenue: -1 } },
+      { $limit: 5 },
+      {
+        $lookup: {
+          from: "products",
+          localField: "_id",
+          foreignField: "_id",
+          as: "product",
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          productId: "$_id",
+          unitsSold: 1,
+          revenue: 1,
+          name: {
+            $ifNull: [
+              { $arrayElemAt: ["$product.name", 0] },
+              "Unknown product",
+            ],
+          },
+          image: {
+            $ifNull: [
+              { $arrayElemAt: ["$product.images.url", 0] },
+              null,
+            ],
+          },
+        },
+      },
+    ];
+
+    const [summaryResult, revenueTrend, orderGrowth, topProducts] =
+      await Promise.all([
+        OrderModel.aggregate(summaryPipeline),
+        OrderModel.aggregate(revenueTrendPipeline),
+        OrderModel.aggregate(orderGrowthPipeline),
+        OrderModel.aggregate(topProductsPipeline),
+      ]);
+
+    // ----- Normalise the faceted summary into a flat, safe shape -----
+    const facet = summaryResult[0] || {};
+    const totalRevenue = facet.revenue?.[0]?.totalRevenue || 0;
+    const paidOrders = facet.revenue?.[0]?.paidOrders || 0;
+    const totalUnits = facet.units?.[0]?.totalUnits || 0;
+    const totalOrders = facet.allOrders?.[0]?.count || 0;
+    const averageOrderValue = paidOrders > 0 ? totalRevenue / paidOrders : 0;
+
+    const statusDistribution = (facet.byStatus || []).map((s) => ({
+      status: s._id || "UNKNOWN",
+      count: s.count,
+    }));
+    const paymentDistribution = (facet.byPayment || []).map((p) => ({
+      status: p._id || "UNKNOWN",
+      count: p.count,
+    }));
+
+    return res.status(200).json({
+      success: true,
+      analytics: {
+        summary: {
+          totalRevenue,
+          totalOrders,
+          paidOrders,
+          totalUnits,
+          averageOrderValue,
+        },
+        revenueTrend,
+        orderGrowth,
+        topProducts,
+        statusDistribution,
+        paymentDistribution,
+        range: {
+          startDate: startDate || null,
+          endDate: endDate || null,
+          interval,
+        },
+      },
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: error.message,
+    });
+  }
+});

--- a/server/route/orderRoute.js
+++ b/server/route/orderRoute.js
@@ -11,6 +11,7 @@ import {
   updateOrderStatus,
 } from "../controllers/orderController.js";
 import admin from "../middleware/Admin.js";
+import { getOrderAnalytics } from "../controllers/analyticsController.js";
 
 const orderRouter = express.Router();
 
@@ -19,6 +20,8 @@ orderRouter.post("/create", auth, createOrder);
 orderRouter.get("/myorder", auth, myOrders);
 
 orderRouter.get("/get/admin", auth, admin, getAllOrders);
+
+orderRouter.get("/admin/analytics", auth, admin, getOrderAnalytics);
 
 orderRouter.get("/get/:orderId", auth, getSingleOrder);
 


### PR DESCRIPTION
Closes #38 

## Overview

This PR implements a complete **Order Analytics Dashboard** for the Faith & Fast admin panel. All metrics are computed inside MongoDB via aggregation pipelines — no order documents are pulled into Node.js memory and reduced client-side. The dashboard is wired through the existing Redux/Axios architecture, protected by the existing `auth + admin` middleware chain, and rendered with Recharts inside the existing `AdminDashboard` sidebar layout. It satisfies every requirement and acceptance criterion from the issue, plus the maintainer's specific direction in the assignment comment.

---

## Problem Statement

The existing admin panel had no analytics capability beyond a list of orders. Administrators had no way to answer questions like:

- How much revenue did we generate this month?
- Which products are selling the most?
- Is order volume growing or declining?
- How are orders distributed across statuses (Pending / Shipped / Delivered / Cancelled)?
- What is the average value of an order?

All of these required manually scanning the orders table. For a growing e-commerce platform, this is unsustainable.

---

## Architecture Decisions

### 1. Aggregation endpoint (not client-side compute)
The maintainer explicitly required a dedicated aggregation-based analytics endpoint for performance and scalability. The new `GET /api/order/admin/analytics` endpoint runs **four aggregation pipelines in parallel via `Promise.all`** — MongoDB does all the grouping, summing, bucketing, and joining. Node.js receives only the final computed result (a few numbers and small arrays), not the full orders collection.

### 2. Revenue definition
"Revenue" / "Sales" is defined as the sum of `totalAmount` over orders whose `orderStatus` is **not CANCELLED**. A cancelled order represents no realized sale. Order-Growth counts all orders (including cancelled) so the two time-series answer different questions and stay distinct. This is documented in the controller's JSDoc.

### 3. Recharts v2
The issue specifies Recharts as the preferred charting library for React compatibility. Recharts v3 requires React 19; this project uses React 18, so **recharts@^2.15.4** was installed — the latest stable v2 release, fully compatible with the existing stack.

### 4. Route placement
The analytics route lives in `orderRoute.js` (not a new file) because analytics are derived directly from the Order model. No changes to `server/index.js` are needed — `orderRouter` is already mounted there.

### 5. Redux slice placement
`analyticsSlice.js` lives in `client/src/store/order-slice/` alongside `AdminOrderSlice.js` — same feature domain, same folder, same pattern.

---

## Files Changed

### `server/controllers/analyticsController.js` — NEW

The core of this PR. A single exported function `getOrderAnalytics` wrapped in `catchAsyncErrors`, following the exact same style as every existing controller (inner try/catch, `{ success, message }` response shape).

**Query parameters (all optional):**
- `startDate` — ISO date string; filters `createdAt >= startDate` (validated with `isNaN(Date)` guard)
- `endDate` — ISO date string; filters `createdAt <= endDate` inclusive (sets hours to 23:59:59.999)
- `interval` — `"day"` | `"month"` (default: `"day"`) — controls the time-series bucket size

**Pipeline 1 — Summary (`$facet`)**

Runs four sub-pipelines in a single aggregation pass using `$facet`:
- `revenue`: `$match { orderStatus: { $ne: "CANCELLED" } }` → `$group` sum of `totalAmount` + count of non-cancelled orders
- `units`: same non-cancelled match → `$unwind "$products"` → `$group` sum of `products.quantity`
- `allOrders`: `$count` of all orders in range (including cancelled)
- `byStatus`: `$group` by `orderStatus` → count per status (feeds status-distribution pie chart)
- `byPayment`: `$group` by `paymentStatus` → count per payment state

Output after normalization:
```json
{
  "totalRevenue": 12500,
  "totalOrders": 48,
  "paidOrders": 41,
  "totalUnits": 127,
  "averageOrderValue": 304.88
}
```

**Pipeline 2 — Revenue Trend**

`$match` non-cancelled + date range → `$group` by `$dateToString` on `createdAt` (format `%Y-%m-%d` or `%Y-%m` based on interval) → sum `totalAmount` + count orders → `$sort` ascending → `$project` clean `{ period, revenue, orders }` shape.

**Pipeline 3 — Order Growth**

Same as Revenue Trend but matches **all** orders (including cancelled) — so Growth counts every order placed, not just realized sales. This gives the admin a view of demand volume regardless of fulfilment outcome.

**Pipeline 4 — Top-Selling Products**

`$match` non-cancelled + date range → `$unwind "$products"` → `$group` by `products.product` (the ObjectId ref) summing `products.quantity` (units) and `products.quantity * products.price` (revenue, with `$ifNull` guards for missing prices) → `$sort` by unitsSold desc then revenue desc → `$limit 5` → `$lookup` into the `products` collection for name and first image URL → `$project` clean shape.

The `$lookup` target collection is `"products"` — Mongoose pluralizes the model name `"Product"` to this collection name automatically.

**Edge cases handled:**
- Empty database / no orders in range → all `$group` stages return `[]`, safe optional-chain fallback (`?.`) produces zeros; frontend shows empty state (not a 404 error)
- `products.price` not set on a line item → `$ifNull` wraps both quantity and price to 0, preventing NaN in revenue
- AOV divide-by-zero → `paidOrders > 0` guard before division
- Invalid `startDate`/`endDate` → `isNaN(new Date(value).getTime())` check skips the filter silently
- `orderStatus` null in data → mapped to `"UNKNOWN"` in status distribution

**Response shape:**
```json
{
  "success": true,
  "analytics": {
    "summary": { "totalRevenue": 0, "totalOrders": 0, "paidOrders": 0, "totalUnits": 0, "averageOrderValue": 0 },
    "revenueTrend": [{ "period": "2026-01-10", "revenue": 1200, "orders": 3 }],
    "orderGrowth":  [{ "period": "2026-01-10", "orders": 4 }],
    "topProducts":  [{ "productId": "...", "name": "Cotton Tee", "unitsSold": 12, "revenue": 2400, "image": "https://..." }],
    "statusDistribution": [{ "status": "DELIVERED", "count": 20 }],
    "paymentDistribution": [{ "status": "COMPLETED", "count": 18 }],
    "range": { "startDate": null, "endDate": null, "interval": "day" }
  }
}
```

---

### `server/route/orderRoute.js` — EDITED

**Two additions only:**

```js
// Import (top of file, alongside existing admin import)
import { getOrderAnalytics } from "../controllers/analyticsController.js";

// Route (placed with the other admin GETs)
orderRouter.get("/admin/analytics", auth, admin, getOrderAnalytics);
```

- Uses the same `auth, admin` middleware chain as `/get/admin` and `/admin/update/:orderId`
- Placed **before** `/get/:orderId` in the file — but this doesn't matter for routing since `/admin/analytics` has no overlap with `/:orderId` param routes
- Full URL when mounted: `GET /api/order/admin/analytics`
- No changes to `server/index.js` — orderRouter is already mounted there

---

### `client/src/store/order-slice/analyticsSlice.js` — NEW

Mirrors `AdminOrderSlice.js` exactly in structure and style:

```js
createAsyncThunk("adminAnalytics/getOrderAnalytics", async (params, { rejectWithValue }) => {
  const token = localStorage.getItem("token");
  const response = await axiosInstance.get("/api/order/admin/analytics", {
    headers: { Authorization: `Bearer ${token}` },
    params: { startDate, endDate, interval },
    withCredentials: true,
  });
  return response.data.analytics;
})
```

- Imports `axiosInstance` from `@/api` (the existing configured Axios instance with the 401 interceptor)
- Reads token from `localStorage.getItem("token")` — same as every other slice
- Accepts `{ startDate, endDate, interval }` params object → passes as query params
- Returns `response.data.analytics` on fulfilled
- `rejectWithValue(error.response?.data?.message || error.message)` on error
- Slice state: `{ analytics: null, loading: false, error: null }`
- Exports: `getOrderAnalytics` thunk, `clearAnalytics` action, default reducer

---

### `client/src/store/store.js` — EDITED

**Two additions only:**

```js
import adminAnalyticsReducer from "./order-slice/analyticsSlice";
// ...
adminAnalytics: adminAnalyticsReducer,
```

Registered alongside `adminOrders: adminOrdersReducer` — same namespace convention.

---

### `client/src/pages/admin/AdminAnalytics.jsx` — NEW

The main dashboard component. Clean, reusable, mobile-responsive. Uses `useSelector(state => state.adminAnalytics)` + `useDispatch`.

**Subcomponents (defined in the same file, PropTypes validated):**

`StatCard` — renders one summary metric tile:
- Props: `icon` (lucide component), `label` (string), `value` (formatted string), `accent` (Tailwind bg class)
- Layout: icon in coloured square left, label + value right
- Responsive: `grid-cols-1 sm:grid-cols-2 xl:grid-cols-4` for the 4-card row

`ChartCard` — wraps any Recharts chart with a title, subtitle, and graceful empty state:
- Props: `title`, `subtitle`, `isEmpty` (bool), `emptyText`, `children`
- When `isEmpty`: renders a centred `h-[260px]` empty-state message instead of the chart
- Consistent `bg-white dark:bg-gray-800 rounded-xl shadow-sm border` framing

**Charts (all wrapped in `ResponsiveContainer width="100%" height="100%"`):**

1. **Revenue Trend** — `LineChart` with `Line type="monotone"` on `revenue` field, green (`#10b981`), `dot={false}`, currency tooltip formatter (`₹` INR via `Intl.NumberFormat`)
2. **Order Growth** — `AreaChart` with `Area type="monotone"` on `orders`, blue (`#3b82f6`), gradient fill via `<linearGradient>` def
3. **Top-Selling Products** — `BarChart layout="vertical"` with horizontal bars on `unitsSold`, purple (`#8b5cf6`), `radius={[0,4,4,0]}`, `YAxis type="category" dataKey="name" width={110}` for product name labels
4. **Order Status Distribution** — `PieChart` with `Pie dataKey="count" nameKey="status"`, per-status colours (`PENDING`=amber, `SHIPPED`=blue, `DELIVERED`=emerald, `CANCELLED`=red), `Legend` and `Tooltip`

**Date-range controls:**
- `From` / `To` date inputs with `max`/`min` cross-constraints (can't set end before start)
- `Group by` select: Day / Month
- `Apply` button → dispatches with current date params
- `Reset` button (with `RefreshCw` lucide icon) → clears dates, resets to day interval, refetches

**Loading / error / empty states** (matching `AdminOrdersPage` convention exactly):
- Loading: centred `<CircularProgress />` from MUI (same as every other admin page)
- Error: `<p className="text-center text-red-500 py-16">` with the error message
- No data: friendly empty state paragraph with guidance text
- Per-chart empty: each `ChartCard` has its own `isEmpty` + `emptyText` so individual charts degrade gracefully if a specific metric has no data

**Dark mode:** full `dark:` Tailwind class coverage on all backgrounds, text, borders, and inputs — consistent with the existing admin pages.

**Currency formatting:** `Intl.NumberFormat("en-IN", { style: "currency", currency: "INR", maximumFractionDigits: 0 })` — produces `₹` prefix with Indian number grouping (lakhs/crores), matching the COD/Indian-market context of this app.

**`MetaData` component:** used for page title/description/keywords — matches every other admin page in the repo.

---

### `client/src/pages/admin/AdminDashboard.jsx` — EDITED

**Three additions only:**

```js
// Import (top, with other lucide icons)
import { ..., BarChart3 } from "lucide-react";

// Import (after AdminOrdersPage)
import AdminAnalytics from "./AdminAnalytics";

// Nav array entry (after Orders)
{ icon: BarChart3, text: "Analytics" },

// Switch case (after Orders)
case "Analytics":
  return <AdminAnalytics />;
```

The Analytics section appears in the sidebar below Orders, using `BarChart3` from lucide-react (already a dependency). Clicking it sets `activeSection = "Analytics"` and renders `<AdminAnalytics />` in the main content area — identical to how Orders/Products/Customers work.

---

### `client/package.json` + `client/package-lock.json` — EDITED

Single new dependency added:

```json
"recharts": "^2.15.4"
```

Recharts v2.15.4 is the latest stable v2 release, fully compatible with React 18. Recharts v3 requires React 19 — v2 is the correct choice for this project's stack.

---

## Acceptance Criteria

- [x] **Dashboard implemented** — Order Analytics view accessible from the Admin sidebar under "Analytics"
- [x] **Charts integrated** — 4 Recharts charts: revenue trend (line), order growth (area), top products (horizontal bar), status distribution (pie)
- [x] **Analytics API created** — `GET /api/order/admin/analytics` using MongoDB aggregation pipelines, admin-only
- [x] **Mobile responsiveness maintained** — `ResponsiveContainer` on all charts, responsive grid layouts, mobile-friendly date controls

### Functional Requirements

- [x] **Total Sales** — displayed as a summary stat card (sum of `totalAmount` on non-cancelled orders) + revenue trend chart
- [x] **Revenue Trends** — line chart bucketed by day or month with date-range filter
- [x] **Top-Selling Products** — horizontal bar chart of top 5 products by units sold, with product names from `$lookup`
- [x] **Order Growth** — area chart of order volume over time (all orders including cancelled)
- [x] **AOV (bonus)** — Average Order Value stat card
- [x] **Status Distribution (bonus)** — pie chart of order counts by status
- [x] **Admin-only access** — `auth, admin` middleware chain on the endpoint
- [x] **Loading state** — MUI `CircularProgress` while fetching
- [x] **Error state** — red error message if API call fails
- [x] **Empty state** — friendly guidance message when no orders exist, per-chart empty states
- [x] **Date-range filter** — `startDate`/`endDate` query params, validated server-side
- [x] **Day/month interval toggle** — `interval` param controls `$dateToString` format

---

## Verification

**Backend syntax:** `node --check server/controllers/analyticsController.js` → passes  
**Backend syntax:** `node --check server/route/orderRoute.js` → passes

**Frontend ESLint:** `npx eslint src/pages/admin/AdminAnalytics.jsx src/store/order-slice/analyticsSlice.js src/pages/admin/AdminDashboard.jsx` → exit 0, zero errors, zero warnings (PropTypes added to both subcomponents per repo convention)

**Vite production build:** `npx vite build` → `✓ 14,564 modules transformed. ✓ built in 27.93s` — recharts resolves correctly, no import errors

**Aggregation logic verified (24 assertions)** on a representative 4-order dataset:
- `totalRevenue` = sum of non-cancelled `totalAmount` only ✓
- Cancelled orders excluded from revenue/units/top-products ✓
- Cancelled orders included in order-growth + status-distribution ✓
- AOV = totalRevenue / paidOrders (divide-by-zero guarded) ✓
- Top-products tie-break by revenue when units equal ✓
- Product `$lookup` retrieves name and first image URL; null fallback when `images[]` is empty ✓
- Revenue trend and order-growth bucket correctly by day and by month ✓
- Date-range filter (`startDate`/`endDate`) correctly excludes out-of-range orders ✓
- Empty DB → all zeros + empty arrays (no 404, no crash) ✓

---

## How the Admin Uses It

1. Log in as ADMIN → navigate to `/admin`
2. Click **"Analytics"** in the left sidebar
3. View the 4 summary stat cards (Total Sales, Total Orders, AOV, Units Sold)
4. View the 4 charts below: Revenue Trend, Order Growth, Top Products, Status Distribution
5. Optionally set a **From** / **To** date range and click **Apply** to filter all charts to that window
6. Toggle **Group by: Day / Month** to zoom out for a monthly view
7. Click **Reset** to return to the all-time view

---

## What Was Not Changed

- `server/index.js` — no change needed; `orderRouter` already mounted at `/api/order`
- `server/models/orderModel.js` — aggregation reads existing fields only, no schema changes
- Any existing admin page (`AdminOrdersPage`, `AdminProducts`, `AdminUsers`) — untouched
- Any existing Redux slice (`AdminOrderSlice`, `order`) — untouched
- Any existing route — untouched; one route added, nothing removed or modified
