### PR TITLE
Add recently viewed products feature

### DIFF
--- a/client/src/pages/components/RecentlyViewed.jsx
+++ b/client/src/pages/components/RecentlyViewed.jsx
@@ -1,0 +1,21 @@
+import ProductCard from "../products/ProductCard";
+
+const RecentlyViewed = ({ products }) => {
+  if (!products || products.length === 0) return null;
+
+  return (
+    <div className="mt-16">
+      <h2 className="text-3xl font-bold text-gray-800 dark:text-white mb-8">
+        Recently Viewed
+      </h2>
+
+      <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        {products.map((product) => (
+          <ProductCard key={product._id} product={product} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RecentlyViewed;

--- a/client/src/pages/products/SingleProduct.jsx
+++ b/client/src/pages/products/SingleProduct.jsx
@@ -10,6 +10,7 @@ import {
 } from "@/store/product-slice/productDetails";
 import ImageSlider from "./ImageSlider";
 import ProductCard from "./ProductCard";
+import RecentlyViewed from "../components/RecentlyViewed";
 import MetaData from "../extras/MetaData";
 import { Button, Rating } from "@mui/material";
 import { Heart, ShoppingCartIcon } from "lucide-react";
@@ -37,6 +38,7 @@ const ProductDetails = ({ products }) => {
   const [selectedColor, setSelectedColor] = useState("");
   const [selectedSize, setSelectedSize] = useState("");
   const [visibleReviews, setVisibleReviews] = useState([]);
+  const [recentlyViewed, setRecentlyViewed] = useState([]);
 
   const containerVariants = {
     hidden: { opacity: 0 },
@@ -102,6 +104,33 @@ const ProductDetails = ({ products }) => {
       dispatch(getSimilarProducts(product.category));
     }
   }, [dispatch, product]);
+
+  useEffect(() => {
+    if (product && product._id) {
+      let viewedProducts =
+        JSON.parse(localStorage.getItem("recentlyViewed")) || [];
+
+      viewedProducts = viewedProducts.filter(
+        (item) => item._id !== product._id
+      );
+
+      viewedProducts.unshift(product);
+
+      viewedProducts = viewedProducts.slice(0, 8);
+
+      localStorage.setItem(
+        "recentlyViewed",
+        JSON.stringify(viewedProducts)
+      );
+
+      const filteredViewed = viewedProducts.filter(
+        (item) => item._id !== product._id
+      );
+
+      setRecentlyViewed(filteredViewed);
+    }
+  }, [product]);
+
 
   useEffect(() => {
     const combined = [...(similarProducts || []), ...(products || [])];
@@ -631,6 +660,7 @@ const ProductDetails = ({ products }) => {
                   ))}
                 </div>
               </motion.section>
+              <RecentlyViewed products={recentlyViewed} />
             </div>
           )}
         </AnimatePresence>


### PR DESCRIPTION
## Related Issue

Fixes #36

## Description of Changes

Implemented a recently viewed products feature to improve product rediscovery and user engagement during browsing sessions.

### Changes Made

* Added automatic product view tracking on product detail pages
* Implemented a reusable `RecentlyViewed` component
* Stored recently viewed products using `localStorage` for session persistence
* Added duplicate prevention logic to avoid repeated entries
* Added maximum item limit handling to keep only the latest viewed products
* Integrated a responsive recently viewed products section below the product details page

## Type of Change

* [x] New feature (non-breaking change which adds functionality)

## Screenshots

Added a "Recently Viewed" section displaying previously visited products below the product details page.

## Testing Performed

Tested the following locally:

* Verified products are automatically added to recently viewed list when opening product pages
* Confirmed duplicate products are not added multiple times
* Tested maximum item limit behavior
* Verified persistence across page refreshes using localStorage
* Checked responsive layout on multiple screen sizes
* Tested navigation between multiple products to ensure recently viewed products update correctly

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [x] I have checked that there are no merge conflicts
* [x] I have linked the PR to the relevant issue