### PR TITLE
fix(ux): replace full-page reloads with reactive state updates in admin and user flows (Closes #65)

### DIFF
--- a/client/src/pages/admin/AdminProducts.jsx
+++ b/client/src/pages/admin/AdminProducts.jsx
@@ -51,7 +51,9 @@ const AdminProducts = () => {
       .unwrap()
       .then(() => {
         setOpenDeleteDialog(false);
-        window.location.reload();
+        // Re-fetch the current page reactively instead of a full reload,
+        // preserving scroll position and the active search/page state.
+        dispatch(getProductByFilter({ page, limit: 10, searchQuery }));
       })
       .catch((err) => {
         console.log("Error deleting product:", err);

--- a/client/src/pages/my-profile/OrderDetails.jsx
+++ b/client/src/pages/my-profile/OrderDetails.jsx
@@ -104,7 +104,8 @@ const OrderDetails = () => {
     try {
       await dispatch(cancelOrder(order._id)).unwrap();
       toast.success("Order canceled successfully!");
-      window.location.reload();
+      // Re-fetch this order so the status updates in place, no full reload.
+      dispatch(getSingleOrder(Id));
     } catch (error) {
       toast.error(error || "Failed to cancel order.");
     } finally {

--- a/client/src/pages/my-profile/SavedAddress.jsx
+++ b/client/src/pages/my-profile/SavedAddress.jsx
@@ -125,9 +125,12 @@ const SavedAddress = () => {
 
     dispatch(deleteUserAddress(id))
       .unwrap()
-      .then(() => toast.success("Address deleted successfully!"))
+      .then(() => {
+        toast.success("Address deleted successfully!");
+        // Refresh the address list from state instead of reloading the page.
+        dispatch(userAddress());
+      })
       .catch((err) => toast.error(err.message || "Failed to delete address"));
-    window.location.reload();
   };
 
   const handleAddAddress = (e) => {

--- a/client/src/pages/products/SingleProduct.jsx
+++ b/client/src/pages/products/SingleProduct.jsx
@@ -226,11 +226,16 @@ const ProductDetails = ({ products }) => {
         productId,
         reviewData: { rating, comment: reviewText, name: user.name },
       })
-    );
-    toast.success("Review posted successfully");
-    window.location.reload();
-    setReviewText("");
-    setRating(0);
+    )
+      .unwrap()
+      .then(() => {
+        toast.success("Review posted successfully");
+        // Re-fetch reviews so the new one appears without a page reload.
+        dispatch(getProductReviews(productId));
+        setReviewText("");
+        setRating(0);
+      })
+      .catch((err) => toast.error(err?.message || "Failed to post review"));
   };
 
   const handleAddCart = (item) => {


### PR DESCRIPTION
## Summary

Fixes the full-page refresh anti-patterns identified in #65.
Four locations across the admin and user-facing flows were calling
`window.location.reload()` after successful actions. Each has been
replaced with a targeted Redux re-dispatch so the UI updates
reactively — scroll position is preserved, the loading spinner
stays local, and no unnecessary network round-trips occur outside
the specific data that changed.

Closes #65

---

## Root cause

Each location used `window.location.reload()` as a shortcut to
reflect updated server state. Beyond the poor UX, one of the four
had a **correctness bug**: `SavedAddress.jsx` fired `reload()` 
*synchronously outside* the `.then()` callback — meaning the
page refreshed before the async delete had finished, potentially
showing stale data if the network was slow.

---

## Changes — file by file

### `client/src/pages/admin/AdminProducts.jsx`

**Before**
```js
.then(() => {
  setOpenDeleteDialog(false);
  window.location.reload();
})
```

**After**
```js
.then(() => {
  setOpenDeleteDialog(false);
  dispatch(getProductByFilter({ page, limit: 10, searchQuery }));
})
```

Re-dispatches the same thunk the `useEffect` uses, with the
current `page` and `searchQuery` state — so pagination and
active search are preserved after deletion.

---

### `client/src/pages/my-profile/SavedAddress.jsx`

**Before** (correctness bug — `reload()` outside `.then()`)
```js
dispatch(deleteUserAddress(id))
  .unwrap()
  .then(() => toast.success("Address deleted successfully!"))
  .catch(...);
window.location.reload(); // ← fires before delete completes
```

**After**
```js
dispatch(deleteUserAddress(id))
  .unwrap()
  .then(() => {
    toast.success("Address deleted successfully!");
    dispatch(userAddress()); // refresh list in place
  })
  .catch(...);
```

`userAddress()` is already imported and called in the `useEffect`
on mount — reusing the same thunk here is consistent and correct.

---

### `client/src/pages/my-profile/OrderDetails.jsx`

**Before**
```js
await dispatch(cancelOrder(order._id)).unwrap();
toast.success("Order canceled successfully!");
window.location.reload();
```

**After**
```js
await dispatch(cancelOrder(order._id)).unwrap();
toast.success("Order canceled successfully!");
dispatch(getSingleOrder(Id));
```

`getSingleOrder` is already imported and used in the component's
`useEffect`. Re-dispatching it updates the order status badge and
the progress tracker in place.

---

### `client/src/pages/products/SingleProduct.jsx`

**Before** (two bugs: unhandled promise + dead code after reload)
```js
dispatch(postReview({ productId, reviewData: { ... } }));
toast.success("Review posted successfully");
window.location.reload(); // ← wipes page before setters run
setReviewText("");         // ← dead code, never reached
setRating(0);              // ← dead code, never reached
```

**After**
```js
dispatch(postReview({ productId, reviewData: { ... } }))
  .unwrap()
  .then(() => {
    toast.success("Review posted successfully");
    dispatch(getProductReviews(productId)); // show new review
    setReviewText("");
    setRating(0);
  })
  .catch((err) => toast.error(err?.message || "Failed to post review"));
```

The review dispatch is now awaited via `.unwrap()`, the form
resets inside `.then()` so it only clears on success, and
`getProductReviews` re-fetches so the new review appears
immediately without any page reload.

---

## Files changed

| File | Change | Anti-pattern fixed |
|---|---|---|
| `client/src/pages/admin/AdminProducts.jsx` | +3 −1 | reload after product delete |
| `client/src/pages/my-profile/SavedAddress.jsx` | +4 −2 | reload (outside .then) after address delete |
| `client/src/pages/my-profile/OrderDetails.jsx` | +2 −1 | reload after order cancel |
| `client/src/pages/products/SingleProduct.jsx` | +11 −5 | reload after review submit + dead code |

4 files · 20 insertions · 9 deletions · 0 new dependencies

---

## Checklist

- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] All `window.location.reload()` calls removed from these flows
- [x] Each replacement re-dispatches the same thunk already used
  in that component's `useEffect` — no new API calls introduced
- [x] All referenced thunks already imported in their files
- [x] SavedAddress correctness bug fixed (reload was outside .then)
- [x] SingleProduct dead code removed (setters now inside .then)
- [x] JSX syntax verified (esbuild — no errors)
- [x] No new dependencies added
- [x] AI-assisted with disclosure