### PR TITLE
fix(auth): gate app-level cart and wishlist fetches behind isAuthenticated (Closes #47)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -46,9 +46,14 @@ const App = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(getCartItems());
-    dispatch(getWishListItems());
-  }, [dispatch]);
+    // Only fetch cart and wishlist for authenticated users. Guests have no
+    // token, so these calls would 401 and surface as error states. Gating
+    // here also re-runs the fetch right after login (isAuthenticated flips).
+    if (isAuthenticated) {
+      dispatch(getCartItems());
+      dispatch(getWishListItems());
+    }
+  }, [dispatch, isAuthenticated]);
 
   return (
     <div className="flex flex-col bg-white dark:bg-black text-black dark:text-white">


### PR DESCRIPTION
## Summary

Fixes the guest API call bug described in #47. The app-level
`useEffect` in `App.jsx` was dispatching `getCartItems()` and
`getWishListItems()` on every mount for every visitor — including
unauthenticated guests who have no token. This caused unnecessary
401 responses from the server and populated `state.error` in the
Redux cart and wishlist slices, surfacing error banners to users
who simply hadn't logged in yet.

Closes #47

---

## Root cause

`App.jsx` already destructured `isAuthenticated` from `state.auth`
at the component top, but it was not used to guard these dispatches:

```js
// Before — fires for guests too, no token → 401 → state.error set
useEffect(() => {
  dispatch(getCartItems());
  dispatch(getWishListItems());
}, [dispatch]);
```

Both thunks read the token from `localStorage` and send it as a
`Bearer` header. When there is no token (guest), the server returns
a 401, the thunk calls `rejectWithValue`, and the Redux rejected
reducer sets `state.error` — causing error banners to appear in
`Cart.jsx` and `Wishlist.jsx` for what is actually a valid empty
state.

---

## Fix

```js
// After — only fetches when the user is authenticated
useEffect(() => {
  // Only fetch cart and wishlist for authenticated users. Guests have no
  // token, so these calls would 401 and surface as error states. Gating
  // here also re-runs the fetch right after login (isAuthenticated flips).
  if (isAuthenticated) {
    dispatch(getCartItems());
    dispatch(getWishListItems());
  }
}, [dispatch, isAuthenticated]);
```

Adding `isAuthenticated` to the dependency array means the effect
re-runs the moment the user logs in, so cart and wishlist data
loads immediately after authentication without any extra trigger.

---

## Why only App.jsx

A full audit of every cart/wishlist dispatch site confirms this is
the only guest-reachable path:

| Location | Reachable by guests? | Action |
|---|---|---|
| `App.jsx` useEffect | ✅ Yes — fires on every mount | **Fixed — gated behind `isAuthenticated`** |
| `Cart.jsx` useEffect | ❌ No — `/cart` is behind `ProtectedRoute` | No change needed |
| `Wishlist.jsx` useEffect | ❌ No — `/wishlist` is behind `ProtectedRoute` | No change needed |
| `Checkout.jsx` useEffect | ❌ No — `/checkout` is behind `ProtectedRoute` | No change needed |
| `Header.jsx` | ❌ No — only reads from Redux state, never dispatches a fetch | No change needed |

The `Header.jsx` badge counts (`cartItems.length`, `WishListItems.length`)
read directly from Redux state — they do not trigger any API call.
Since the cart slice's `initialState` is `cartItems: []`, guests
see no badge, which is the correct empty state.

---

## Files changed

| File | Change |
|---|---|
| `client/src/App.jsx` | +8 −3 |

1 file · 8 insertions · 3 deletions · 0 new dependencies

---

## Checklist

- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] Root cause identified: app-level dispatch in `App.jsx` fires for guests
- [x] `isAuthenticated` was already destructured in scope — no new imports
- [x] `isAuthenticated` added to `useEffect` dep array — fetch re-runs on login
- [x] All other cart/wishlist dispatch sites confirmed behind `ProtectedRoute`
- [x] `Header.jsx` confirmed read-only — does not dispatch fetches
- [x] Guest sees correct empty state (`cartItems: []` initial state)
- [x] JSX syntax verified (esbuild — no errors)
- [x] No new dependencies added
- [x] AI-assisted with disclosure