### PR TITLE
perf(homepage): remove redundant getProducts dispatch from ProductCategory (Closes #54)

### DIFF
--- a/client/src/pages/components/ProductCategory.jsx
+++ b/client/src/pages/components/ProductCategory.jsx
@@ -11,7 +11,6 @@ import {
 import Typewriter from "typewriter-effect";
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
-import { getProducts } from "@/store/product-slice/productSlice";
 import { toast } from "react-toastify";
 import { addToWishList } from "@/store/add-to-wishList/addToWishList";
 
@@ -21,10 +20,6 @@ const ProductCategory = ({ title, items }) => {
   const [shuffledItems, setShuffledItems] = useState([]);
   const navigate = useNavigate();
   const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(getProducts());
-  }, [dispatch]);
 
   useEffect(() => {
     const shuffleArray = (array) => {


### PR DESCRIPTION
## Summary

Fixes the redundant product-fetching issue described in #54.
`ProductCategory.jsx` was dispatching `getProducts()` on every
mount despite never reading the result — all its data arrives via
the `items` prop from the parent `Home.jsx`. Since `Home.jsx`
renders one `ProductCategory` per product category, this caused
**N + 1 identical `/products` API calls** on every homepage load
(1 from `Home`, N from each `ProductCategory` instance), where N
is the number of distinct categories in the catalogue.

Closes #54

---

## Root cause

`Home.jsx` fetches all products once via `getProducts()`, reduces
them into per-category groups, and passes each group as an `items`
prop to `ProductCategory`. `ProductCategory` uses `items` (the
prop) for everything: shuffling, pagination, and rendering. It
**never reads from Redux state** after its own fetch completes —
making the dispatch completely dead.

```js
// ProductCategory.jsx — BEFORE (dead fetch, repeated N times)
import { getProducts } from "@/store/product-slice/productSlice";

useEffect(() => {
  dispatch(getProducts()); // result never used — items come from props
}, [dispatch]);
```

With 5 product categories on the homepage, this produced
**6 identical GET /products calls** on every load instead of 1.

---

## Fix

Removed the dead `useEffect` and its now-unused `getProducts`
import. `dispatch` and `useDispatch` are retained because
`handleAddWishList` still dispatches `addToWishList`.
The two legitimate `useEffect` calls (shuffle items on prop change,
responsive resize handler) are completely untouched.

```js
// ProductCategory.jsx — AFTER (data correctly received via props)
// No getProducts import. No redundant dispatch.
// dispatch retained for addToWishList.

useEffect(() => {
  setShuffledItems(shuffleArray(items)); // items from props ✓
}, [items]);

useEffect(() => {
  // responsive itemsPerView — unchanged
}, []);
```

---

## Full audit of homepage fetch sites

| Component | Fetches products? | Verdict |
|---|---|---|
| `Home.jsx` | ✅ Yes — `getProducts()` once in `useEffect` | **Correct — keep** |
| `ProductCategory.jsx` | ✅ Yes — `getProducts()` on every instance mount | **Dead fetch — removed** |
| `BannerProduct.jsx` | ❌ No — `useEffect` is an image carousel timer only | No change needed |
| `CategoryPanel.jsx` | ❌ No — no dispatch at all | No change needed |

---

## Files changed

| File | Change |
|---|---|
| `client/src/pages/components/ProductCategory.jsx` | +0 −5 |

1 file · 0 insertions · 5 deletions · 0 new dependencies

---

## Checklist

- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] Root cause confirmed: `ProductCategory` dispatches `getProducts()`
  but never reads the result — all data comes via `items` prop
- [x] All homepage fetch sites audited — only `Home.jsx` fetch is legitimate
- [x] `dispatch`/`useDispatch` retained for `addToWishList`
- [x] Both remaining `useEffect` calls (shuffle, resize) untouched
- [x] `getProducts` fully removed — import and call (0 occurrences)
- [x] JSX syntax verified (esbuild — no errors)
- [x] No new dependencies added
- [x] AI-assisted with disclosure