### PR TITLE
fix(auth): validate JWT expiry at boot and harden session expiry handling (Closes #53)

### DIFF
--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -8,14 +8,31 @@ const axiosInstance = axios.create({
 axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (
-      error.response?.status === 401 &&
-      error.response?.data?.message === "Token expired, please login again"
-    ) {
+    const status = error.response?.status;
+    const message = error.response?.data?.message || "";
+
+    // Treat any 401 that signals an expired or invalid session as a logout
+    // trigger, rather than matching one exact server message. Clearing
+    // storage and doing a full redirect guarantees the Redux auth state is
+    // re-initialised (initialState re-reads the now-cleared token), so the
+    // user is logged out safely and consistently.
+    const isSessionExpired =
+      status === 401 &&
+      (/token expired/i.test(message) ||
+        /login again/i.test(message) ||
+        /jwt expired/i.test(message));
+
+    if (isSessionExpired) {
+      const hadToken = !!localStorage.getItem("token");
       localStorage.removeItem("token");
       localStorage.removeItem("user");
-      window.location.href = "/";
+      // Only redirect if the user was actually in a logged-in state, to avoid
+      // bouncing guests whose requests happened to 401.
+      if (hadToken && window.location.pathname !== "/login") {
+        window.location.href = "/login";
+      }
     }
+
     return Promise.reject(error);
   }
 );

--- a/client/src/store/auth-slice/user.js
+++ b/client/src/store/auth-slice/user.js
@@ -1,5 +1,6 @@
 import axiosInstance from "@/api";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { isTokenValid } from "@/utils/tokenUtils";
 
 export const loginUser = createAsyncThunk(
   "auth/loginUser",
@@ -259,12 +260,21 @@ export const deleteUser = createAsyncThunk(
   }
 );
 
-const storedUser = localStorage.getItem("user");
-const storedToken = localStorage.getItem("token") || null;
+const rawToken = localStorage.getItem("token") || null;
+// Only trust a stored token if it is a valid, unexpired JWT. An expired or
+// malformed token is purged here so the app never boots into a stale
+// "authenticated" state after a refresh.
+const tokenIsValid = isTokenValid(rawToken);
+if (rawToken && !tokenIsValid) {
+  localStorage.removeItem("token");
+  localStorage.removeItem("user");
+}
+const storedToken = tokenIsValid ? rawToken : null;
+const storedUserRaw = tokenIsValid ? localStorage.getItem("user") : null;
 
 const initialState = {
-  user: storedUser ? JSON.parse(storedUser) : null,
-  isAuthenticated: !!storedToken,
+  user: storedUserRaw ? JSON.parse(storedUserRaw) : null,
+  isAuthenticated: tokenIsValid,
   token: storedToken,
   loading: false,
   error: null,

--- a/client/src/utils/tokenUtils.js
+++ b/client/src/utils/tokenUtils.js
@@ -1,0 +1,49 @@
+/**
+ * Lightweight JWT helpers for client-side session validation.
+ *
+ * The auth token issued by the server is a standard JWT whose payload
+ * contains an `exp` claim (expiry, in Unix seconds). These helpers decode
+ * that payload without any external dependency so the app can tell whether
+ * a stored token is still valid before treating the user as authenticated.
+ */
+
+/**
+ * Decode the payload segment of a JWT.
+ * Returns the parsed payload object, or null if the token is missing or
+ * malformed (not a decodable three-part JWT).
+ */
+export const decodeToken = (token) => {
+  if (!token || typeof token !== "string") return null;
+
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+
+  try {
+    // JWT uses base64url; convert to standard base64 before decoding.
+    const base64Url = parts[1];
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const json = decodeURIComponent(
+      atob(base64)
+        .split("")
+        .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
+        .join("")
+    );
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Returns true only when the token exists, decodes cleanly, and its `exp`
+ * claim is in the future. A missing, malformed, or expired token returns
+ * false — so callers can treat "valid token" and "authenticated" as the
+ * same thing.
+ */
+export const isTokenValid = (token) => {
+  const payload = decodeToken(token);
+  if (!payload || typeof payload.exp !== "number") return false;
+
+  // exp is in seconds; Date.now() is in milliseconds.
+  return payload.exp * 1000 > Date.now();
+};


### PR DESCRIPTION
## Summary

Fixes the three auth session issues described in #53: expired tokens
being treated as valid on refresh, inconsistent auth state across
sessions, and a fragile single-string match in the expiry interceptor.

Closes #53

---

## Root cause analysis

**Issue 1 — Expired tokens treated as valid on refresh**

`initialState` in the auth slice bootstrapped auth from token presence:

```js
// Before — only checks IF a token exists, never WHEN it expires
isAuthenticated: !!storedToken,
```

A user who logged in yesterday with a 1-day token would reload the app
today and land in a fully "authenticated" state, see protected UI, then
immediately get 401s on every API call.

**Issue 2 — Auth state inconsistent across refreshes**

Because boot-time `isAuthenticated` ignored expiry, every page refresh
with a stale token re-hydrated the user as logged in. The stale token
and user object also stayed in `localStorage` indefinitely.

**Issue 3 — Interceptor matched one exact server string**

```js
// Before — breaks silently if the server message ever changes
error.response?.data?.message === "Token expired, please login again"
```

Any variation in the server response (different wording, network error,
no `message` field) silently skipped the logout. It also fired for guest
requests, and redirected to `/` (home) rather than `/login`.

---

## Fix — 3 files

### 1. `client/src/utils/tokenUtils.js` (new file)

A lightweight, zero-dependency JWT helper. JWTs are three base64url
segments; the middle segment is the payload JSON containing the `exp`
claim (Unix seconds). `isTokenValid` decodes this without any library
and compares against `Date.now()`.

```js
export const isTokenValid = (token) => {
  const payload = decodeToken(token);
  if (!payload || typeof payload.exp !== "number") return false;
  return payload.exp * 1000 > Date.now();
};
```

Tested against 7 edge cases: expired token → false, valid token → true,
null / empty string / garbage / no-exp claim / two-part token → all false.
No new npm dependencies. No circular imports (tokenUtils imports nothing).

---

### 2. `client/src/store/auth-slice/user.js`

Boot-time initialState now validates the JWT before trusting it:

```js
// After — validates expiry; purges stale token from localStorage
const rawToken = localStorage.getItem("token") || null;
const tokenIsValid = isTokenValid(rawToken);
if (rawToken && !tokenIsValid) {
  localStorage.removeItem("token");
  localStorage.removeItem("user");
}
const storedToken = tokenIsValid ? rawToken : null;
const storedUserRaw = tokenIsValid ? localStorage.getItem("user") : null;

const initialState = {
  user: storedUserRaw ? JSON.parse(storedUserRaw) : null,
  isAuthenticated: tokenIsValid,   // ← now reflects actual validity
  token: storedToken,
  ...
};
```

If the stored token is expired or malformed it is removed from
`localStorage` immediately, so the user boots into a clean guest state
on every refresh.

---

### 3. `client/src/api/index.js`

Hardened the response interceptor:

```js
// After — robust pattern match, guest-safe, redirects to /login
const isSessionExpired =
  status === 401 &&
  (/token expired/i.test(message) ||
    /login again/i.test(message) ||
    /jwt expired/i.test(message));

if (isSessionExpired) {
  const hadToken = !!localStorage.getItem("token");
  localStorage.removeItem("token");
  localStorage.removeItem("user");
  if (hadToken && window.location.pathname !== "/login") {
    window.location.href = "/login";
  }
}
```

Changes from the original:
- Case-insensitive regex patterns instead of one exact string — survives
  any minor server message variation
- `hadToken` guard — guest 401s (no token present) do not trigger a
  redirect
- `pathname !== "/login"` guard — prevents redirect loops
- Redirects to `/login` instead of `/` — the natural destination for
  an expired session
- Hard redirect is intentional: it guarantees Redux re-initialises from
  the now-cleared `localStorage`, so auth state is always consistent

---

## Files changed

| File | Change | Purpose |
|---|---|---|
| `client/src/utils/tokenUtils.js` | +49 (new) | Zero-dep JWT decode + expiry check |
| `client/src/store/auth-slice/user.js` | +15 −3 | Boot validates expiry, purges stale token |
| `client/src/api/index.js` | +21 −6 | Robust interceptor, guest-safe redirect |

3 files · 85 insertions · 9 deletions · 0 new dependencies

---

## Checklist

- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] All 3 issue requirements addressed (detect expiry, safe logout,
  consistent across refreshes)
- [x] `isTokenValid` unit-tested: 7 edge cases all pass
- [x] No new npm dependencies — base64url decoded manually
- [x] No circular imports — `tokenUtils.js` imports nothing
- [x] `@/utils/tokenUtils` path confirmed valid (Vite alias `@` → `./src`)
- [x] Existing `logoutUser` thunk and reducer untouched
- [x] Guest 401s do not trigger session-expiry redirect
- [x] Redirect loop guard (`pathname !== "/login"`) in place
- [x] All 3 files esbuild-verified (no syntax errors)
- [x] AI-assisted with disclosure