### PR TITLE
fix(server): remove duplicate unhandledRejection handler and add graceful shutdown (Closes #64)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -10,15 +10,6 @@ import connectDB from "./config/connectDB.js";
 import errorMiddleware from "./middleware/error.js";
 dotenv.config();
 
-process.on("unhandledRejection", (err) => {
-  console.log(`Error: ${err.message}`);
-  console.log("Shutting down the server due to Unhandled Promise Rejection");
-
-  server.close(() => {
-    process.exit(1);
-  });
-});
-
 cloudinary.config({
   cloud_name: process.env.CLOUDINARY_NAME,
   api_key: process.env.CLOUDINARY_API_KEY,
@@ -91,14 +82,36 @@ app.use("/api/user", userRouter);
 app.use("/api/wishlist", wishListRouter);
 
 connectDB().then(() => {
-  app.listen(PORT, () => console.log(`Server is running on port ${PORT}`));
-});
+  const server = app.listen(PORT, () =>
+    console.log(`Server is running on port ${PORT}`)
+  );
 
-process.on("unhandledRejection", (err) => {
-  console.error(`Error: ${err.message}`);
-  console.error(`Shutting down the server due to Unhandled Promise Rejection`);
+  // Graceful shutdown helper — close the HTTP server so in-flight requests
+  // can finish before the process exits. Log every exit reason distinctly so
+  // operators can tell a crash from a signal-triggered stop in the logs.
+  const shutdown = (reason, code = 1) => {
+    console.error(`[shutdown] reason=${reason} code=${code}`);
+    server.close(() => process.exit(code));
+    // Safety net: force-exit after 10 s if connections linger.
+    setTimeout(() => process.exit(code), 10_000).unref();
+  };
 
-  server.close(() => {
-    process.exit(1);
+  // Single unhandledRejection handler (was duplicated — both fired on every
+  // unhandled rejection, causing a race between two concurrent shutdowns).
+  process.on("unhandledRejection", (err) => {
+    console.error(`[unhandledRejection] ${err?.message ?? err}`);
+    shutdown("unhandledRejection");
   });
+
+  // Synchronous throw that escaped all try/catch blocks.
+  process.on("uncaughtException", (err) => {
+    console.error(`[uncaughtException] ${err?.message ?? err}`);
+    shutdown("uncaughtException");
+  });
+
+  // Container / PM2 / Heroku stop signal — exit cleanly with code 0.
+  process.on("SIGTERM", () => shutdown("SIGTERM", 0));
+
+  // Ctrl-C in development — same clean exit.
+  process.on("SIGINT", () => shutdown("SIGINT", 0));
 });


### PR DESCRIPTION
## Summary
Fixes the duplicate process event handler and inconsistent shutdown logic described in #64. Consolidates all process-level error and signal handling into a single, correct location.

Closes #64

---

## What was wrong (verified against actual code)

`server/index.js` registered `process.on("unhandledRejection", ...)` **twice**:

| Location | Problem |
|---|---|
| Line 12 (top of file) | Fires **before** `server` is defined → `server.close()` throws `ReferenceError` |
| Line 95 (bottom of file) | Correct position but redundant — both handlers fire on every rejection |

Both handlers executing simultaneously creates a race condition: two concurrent `server.close()` + `process.exit()` calls.

Additionally: no `uncaughtException` handler (synchronous throws escape silently), and no `SIGTERM`/`SIGINT` handlers (containers and PM2 can't shut the server down cleanly).

---

## Changes — 1 file modified

**`server/index.js`**
- Removed the broken top-level `unhandledRejection` handler (before `server` existed)
- Moved `const server = app.listen(...)` into `connectDB().then()` so the reference is available before any handlers register
- Replaced the duplicate bottom handler with a single `shutdown(reason, code)` helper that closes the HTTP server gracefully and force-exits after 10 seconds if connections linger
- Added `process.on("uncaughtException", ...)` — synchronous throws no longer crash the process silently
- Added `process.on("SIGTERM", ...)` — clean exit for containers / Heroku / PM2
- Added `process.on("SIGINT", ...)` — clean exit for Ctrl-C in development

---

## Checklist
- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] Duplicate `unhandledRejection` handler removed (was firing twice simultaneously)
- [x] Broken top-level handler removed (`server` was not yet defined at that point)
- [x] `server` reference captured before handlers registered
- [x] Single `shutdown()` helper — no race condition possible
- [x] `uncaughtException` handler added
- [x] `SIGTERM` + `SIGINT` handlers added for graceful container/PM2 shutdown
- [x] 10-second force-exit safety net added
- [x] 1 file modified · 0 new files · 0 new dependencies