### PR TITLE
fix(security): add auth and admin middleware to DELETE /admin/delete-all orders route (Closes #56)

### DIFF
--- a/server/route/orderRoute.js
+++ b/server/route/orderRoute.js
@@ -48,6 +48,6 @@ orderRouter.put("/cancel/:orderId", auth, cancelOrder);
 
 orderRouter.delete("/admin/delete/:orderId", auth, admin, deleteOrder);
 
-orderRouter.delete("/admin/delete-all", deleteAllOrders);
+orderRouter.delete("/admin/delete-all", auth, admin, deleteAllOrders);
 
 export default orderRouter;


### PR DESCRIPTION
## Summary
Fixes the critical authorization gap described in #56. The `DELETE /api/order/admin/delete-all` endpoint had no middleware protection, allowing any unauthenticated request to wipe the entire orders collection.

Closes #56

---

## What was wrong (verified against actual code)

In `server/route/orderRoute.js`, every admin order route correctly uses `auth, admin` middleware — except one:

```js
// Every other admin route — CORRECT
orderRouter.get("/get/admin", auth, admin, getAllOrders);
orderRouter.put("/admin/update/:orderId", auth, admin, updateOrderStatus);
orderRouter.delete("/admin/delete/:orderId", auth, admin, deleteOrder);

// The delete-all route — MISSING auth and admin ❌
orderRouter.delete("/admin/delete-all", deleteAllOrders);
```

The `deleteAllOrders` controller has no authorization check of its own — it calls `OrderModel.deleteMany({})` immediately. Any unauthenticated `DELETE /api/order/admin/delete-all` request permanently wipes all orders.

---

## Fix — 1 line changed

```js
// Before
orderRouter.delete("/admin/delete-all", deleteAllOrders);

// After
orderRouter.delete("/admin/delete-all", auth, admin, deleteAllOrders);
```

---

## Checklist
- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] `auth` middleware added — unauthenticated requests rejected with 401
- [x] `admin` middleware added — non-admin users rejected with 403
- [x] All other admin routes verified unchanged
- [x] `deleteAllOrders` controller verified — no own auth guard, relies entirely on middleware
- [x] 1 file modified · 1 line changed · 0 new dependencies