### PR TITLE
feat(ui): add dismissible promotional offer banner above header (Closes #77)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -32,6 +32,7 @@ import OrderDetails from "./pages/my-profile/OrderDetails";
 import CreateOrder from "./pages/orders/Checkout";
 import ProductUpdatePage from "./pages/admin/AdminUpdateProduct";
 import AdminDiscount from "./pages/admin/AdminDiscount";
+import PromoBanner from "./pages/components/PromoBanner";
 import { useEffect } from "react";
 import { getCartItems } from "./store/add-to-cart/addToCart";
 import { getWishListItems } from "./store/add-to-wishList/addToWishList";
@@ -60,6 +61,7 @@ const App = () => {
     <div className="flex flex-col bg-white dark:bg-black text-black dark:text-white">
       <ToastContainer position="top-center" />
       {/* <DiscountHeader /> */}
+      <PromoBanner />
       <Header />
       <WhatsAppButton />
 

--- a/client/src/pages/components/PromoBanner.jsx
+++ b/client/src/pages/components/PromoBanner.jsx
@@ -1,0 +1,105 @@
+import { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+import { X } from "lucide-react";
+import { fetchDiscounts } from "@/store/extra-slice/discount";
+
+const SESSION_KEY = "promoBannerDismissed";
+
+// Return the best active discount to feature — one that is explicitly active,
+// has not yet expired, and has already started. Prefers PERCENTAGE over FIXED
+// as they're generally more eye-catching.
+const pickDiscount = (discounts) => {
+  const now = new Date();
+  const active = discounts.filter((d) => {
+    if (!d.isActive) return false;
+    if (d.startDate && new Date(d.startDate) > now) return false;
+    if (d.endDate && new Date(d.endDate) < now) return false;
+    return true;
+  });
+  if (active.length === 0) return null;
+  const pct = active.find((d) => d.discountType === "PERCENTAGE");
+  return pct || active[0];
+};
+
+const formatExpiry = (endDate) => {
+  if (!endDate) return null;
+  const end = new Date(endDate);
+  const now = new Date();
+  const msLeft = end - now;
+  if (msLeft <= 0) return null;
+  const hoursLeft = Math.ceil(msLeft / (1000 * 60 * 60));
+  if (hoursLeft <= 48) return `${hoursLeft}h left`;
+  const daysLeft = Math.ceil(msLeft / (1000 * 60 * 60 * 24));
+  return `${daysLeft} days left`;
+};
+
+const PromoBanner = () => {
+  const dispatch = useDispatch();
+  const { discounts } = useSelector((state) => state.discount);
+
+  // Per-session dismiss — the banner reappears on a fresh session (new tab /
+  // browser restart) but not within the same session.
+  const [dismissed, setDismissed] = useState(
+    () => !!sessionStorage.getItem(SESSION_KEY)
+  );
+
+  useEffect(() => {
+    // Only fetch if we don't already have discounts loaded (other components
+    // such as AdminDiscount may have already populated the store).
+    if (discounts.length === 0) {
+      dispatch(fetchDiscounts());
+    }
+  }, [dispatch, discounts.length]);
+
+  const handleDismiss = () => {
+    sessionStorage.setItem(SESSION_KEY, "1");
+    setDismissed(true);
+  };
+
+  if (dismissed) return null;
+
+  const discount = pickDiscount(discounts);
+  if (!discount) return null;
+
+  const valueText =
+    discount.discountType === "PERCENTAGE"
+      ? `${discount.discountValue}% off`
+      : `₹${discount.discountValue} off`;
+
+  const expiry = formatExpiry(discount.endDate);
+
+  return (
+    <div className="relative z-50 w-full bg-gradient-to-r from-yellow-400 via-yellow-300 to-yellow-400 dark:from-yellow-600 dark:via-yellow-500 dark:to-yellow-600 text-yellow-900 dark:text-yellow-950 py-2 px-4">
+      <div className="max-w-7xl mx-auto flex items-center justify-center gap-2 text-center text-sm font-medium pr-6">
+        <span>
+          🎉 Use code{" "}
+          <span className="font-bold tracking-wide bg-yellow-900/10 px-1.5 py-0.5 rounded">
+            {discount.name}
+          </span>{" "}
+          for <span className="font-bold">{valueText}</span>
+          {expiry && (
+            <span className="ml-1 opacity-80 text-xs">— ends in {expiry}</span>
+          )}
+        </span>
+        <Link
+          to="/products"
+          className="ml-2 underline underline-offset-2 font-semibold hover:opacity-75 transition-opacity shrink-0"
+        >
+          Shop Now →
+        </Link>
+      </div>
+
+      {/* Dismiss button */}
+      <button
+        onClick={handleDismiss}
+        aria-label="Dismiss promotional banner"
+        className="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded hover:bg-yellow-900/10 transition-colors"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+};
+
+export default PromoBanner;


### PR DESCRIPTION
## Summary
Implements the promotional offer banner described in #77. A thin, dismissible banner appears above the navigation header whenever an active discount exists, showing the coupon code, value, expiry countdown, and a Shop Now link.

Closes #77

---

## What was already in place (verified before writing any code)

| Layer | Status |
|---|---|
| `state.discount.discounts` in Redux | ✅ Exists — populated by `fetchDiscounts` |
| `DiscountHeader` component | ✅ Exists but is a **full-screen popup modal** (commented out in App.jsx) — not a banner |
| Banner above header/nav | ❌ None |

The existing `DiscountHeader` is a modal overlay requiring user confirmation to dismiss — a different UX entirely. `PromoBanner` is a new thin top bar, independent of `DiscountHeader`.

---

## New files — 1

**`client/src/pages/components/PromoBanner.jsx`**

A thin top bar that:
- Reads `state.discount.discounts` (already in store — no extra fetch if discounts are loaded)
- Calls `fetchDiscounts()` only if the store is empty
- `pickDiscount()` filters to discounts that are `isActive: true`, have started (`startDate ≤ now`), and have not expired (`endDate > now`). Prefers PERCENTAGE discounts as they're more eye-catching
- Displays: 🎉 Use code **CODE** for **N% off** — ends in **Xh left** / **Y days left** + **Shop Now →** link to `/products`
- **Session-persistent dismiss** via `sessionStorage` — banner closes on ✕ click and does not reappear for the rest of the session. Reappears on next visit (new tab / browser restart)
- Renders `null` when no active discounts exist (no empty bar shown)
- Fully mobile responsive — text wraps naturally, dismiss button anchored to right edge

---

## Modified files — 1

**`client/src/App.jsx`**
- Imported `PromoBanner`
- Rendered `<PromoBanner />` directly above `<Header />` (below the commented-out `<DiscountHeader />`)
- The existing `DiscountHeader` comment is preserved unchanged

---

## Design decisions

**New component, not modifying DiscountHeader:** The existing component is a modal overlay with a 2-hour localStorage-based suppress window and a confirmation step before dismissing. The issue asks for a thin banner with session-based dismiss — a different UX pattern. Building separately keeps both options available.

**`pickDiscount` logic:** Filters `isActive`, `startDate`, and `endDate` so only currently-live discounts appear. Prefers PERCENTAGE type since "20% off" reads better in a banner than "₹50 off" for general promotion.

**`sessionStorage` vs `localStorage`:** The issue spec says "dismissed state persists for the session." `sessionStorage` resets on tab/browser close — exactly the right scope.

---

## Checklist
- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] Banner appears above header when active discount exists
- [x] Shows coupon code, discount value, expiry countdown, and Shop Now link
- [x] Only appears when at least one active discount exists (`isActive`, date range checked)
- [x] Dismissible with ✕ button + `aria-label` for accessibility
- [x] Session-persistent dismiss via `sessionStorage`
- [x] Banner does not reappear until next session
- [x] Mobile responsive
- [x] No extra API calls if discounts already loaded in store
- [x] Existing `DiscountHeader` component and comment untouched
- [x] 1 new file + 1 modified · 0 new dependencies