### PR TITLE
feat(product): add Buy Now button, stock availability indicators, and disabled state for out-of-stock products (Closes #48)

### DIFF
--- a/client/src/pages/products/SingleProduct.jsx
+++ b/client/src/pages/products/SingleProduct.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -23,6 +23,7 @@ import { addToWishList } from "@/store/add-to-wishList/addToWishList";
 const ProductDetails = ({ products }) => {
   const { productId } = useParams();
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const {
     product,
     reviews = [],
@@ -247,6 +248,24 @@ const ProductDetails = ({ products }) => {
     toast.success(`"${item.name}" added to cart!`);
   };
 
+  // Buy Now — add the item to the cart, then take the user straight to
+  // checkout, bypassing the cart page. We await the thunk so checkout only
+  // opens once the item is actually in the cart.
+  const handleBuyNow = async (item) => {
+    if (!item) {
+      toast.error("Error: Item not found!");
+      return;
+    }
+    try {
+      await dispatch(
+        addToCart({ productId: item._id, selectedColor, selectedSize })
+      ).unwrap();
+      navigate("/checkout");
+    } catch (err) {
+      toast.error(err || "Could not proceed to checkout. Please try again.");
+    }
+  };
+
   const handleAddWishList = (item) => {
       dispatch(addToWishList(item._id));
       toast.success(`Successfully added to WishList!`);
@@ -318,6 +337,22 @@ const ProductDetails = ({ products }) => {
                       </span>
                     )}
                   </div>
+                  {/* Stock availability indicator */}
+                  <motion.div variants={itemVariants}>
+                    {product?.stock === 0 ? (
+                      <span className="inline-block px-3 py-1 rounded-full text-sm font-semibold bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400">
+                        Out of Stock
+                      </span>
+                    ) : product?.stock <= 5 ? (
+                      <span className="inline-block px-3 py-1 rounded-full text-sm font-semibold bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-400">
+                        Only {product?.stock} left in stock — order soon
+                      </span>
+                    ) : (
+                      <span className="inline-block px-3 py-1 rounded-full text-sm font-semibold bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400">
+                        In Stock
+                      </span>
+                    )}
+                  </motion.div>
                   {product?.reviews?.length > 0 && (
                     <motion.div
                       variants={itemVariants}
@@ -382,7 +417,7 @@ const ProductDetails = ({ products }) => {
                     <Button
                       fullWidth
                       onClick={() => handleAddCart(product)}
-                      disabled={loading}
+                      disabled={loading || product?.stock === 0}
                       sx={{
                         background:
                           "linear-gradient(to right, #f59e0b, #f97316)",
@@ -399,7 +434,31 @@ const ProductDetails = ({ products }) => {
                       }}
                       startIcon={<ShoppingCartIcon />}
                     >
-                      Add to Cart
+                      {product?.stock === 0 ? "Out of Stock" : "Add to Cart"}
+                    </Button>
+                  </motion.div>
+                  <motion.div variants={itemVariants}>
+                    <Button
+                      fullWidth
+                      onClick={() => handleBuyNow(product)}
+                      disabled={loading || product?.stock === 0}
+                      sx={{
+                        background:
+                          "linear-gradient(to right, #16a34a, #15803d)",
+                        color: "white",
+                        padding: "12px 24px",
+                        borderRadius: "9999px",
+                        fontSize: "16px",
+                        fontWeight: "bold",
+                        "&:hover": {
+                          background:
+                            "linear-gradient(to right, #15803d, #166534)",
+                        },
+                        "&:disabled": { opacity: 0.5 },
+                      }}
+                      startIcon={<ShoppingCartIcon />}
+                    >
+                      {product?.stock === 0 ? "Unavailable" : "Buy Now"}
                     </Button>
                   </motion.div>
                   <motion.div variants={itemVariants}>


### PR DESCRIPTION
## Summary
The product detail page had no direct checkout path and no stock visibility. Users were forced to go through the cart regardless of intent, and out-of-stock products showed no indication and remained clickable. This PR adds a Buy Now button, three-state stock indicators, and full purchase action disabling when stock is zero.

Closes #48

---

## What was wrong (verified against code)

`client/src/pages/products/SingleProduct.jsx` (682 lines):
- No `useNavigate` import — no programmatic navigation possible
- `handleAddCart` dispatches to cart only — no direct-to-checkout flow
- No stock indicator of any kind despite `product.stock` being available from the API
- `disabled={loading}` on both buttons — never disabled for out-of-stock

The product model (`server/models/productModel.js` line 60) has `stock: { type: Number, required: true, default: 0, min: 0 }` — the data exists, it just wasn't surfaced.

---

## Fix — 1 file modified (`client/src/pages/products/SingleProduct.jsx`)

**`useNavigate` added** to the `react-router-dom` import and instantiated in the component.

**`handleBuyNow` handler:**
```js
const handleBuyNow = async (item) => {
  try {
    await dispatch(addToCart({ productId: item._id, selectedColor, selectedSize })).unwrap();
    navigate("/checkout");
  } catch (err) {
    toast.error(err || "Could not proceed to checkout. Please try again.");
  }
};
```
Awaits `addToCart` before navigating so the item is confirmed in the cart before checkout opens. Uses the existing cart→checkout path (`/checkout`) — no new routes needed.

**Stock availability indicator** (inserted after price block):
- `stock === 0` → red pill: **Out of Stock**
- `stock <= 5` → orange pill: **Only N left in stock — order soon**
- `stock > 5` → green pill: **In Stock**

**Purchase buttons updated:**
- Add to Cart: `disabled={loading || product?.stock === 0}`, label becomes **"Out of Stock"** when unavailable
- Buy Now (new, green gradient): `disabled={loading || product?.stock === 0}`, label becomes **"Unavailable"** when out of stock
- Wishlist button: unchanged — users can still wishlist out-of-stock items

---

## Checklist
- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] Buy Now button added — bypasses cart, goes directly to `/checkout`
- [x] `addToCart` awaited before navigation — item confirmed in cart before checkout
- [x] Three-state stock indicator (Out of Stock / Low / In Stock)
- [x] Both purchase buttons disabled + relabeled when `stock === 0`
- [x] Wishlist unaffected — users can still save out-of-stock items
- [x] `product.stock` data already available from existing API — no backend changes
- [x] All existing animations and layout preserved
- [x] 1 file modified · 62 insertions · compiles clean