### PR TITLE
feat(orders): implement dedicated invoice page with PDF download, billing details, and itemized breakdown (Closes #50)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,6 +29,7 @@ import AdminUsers from "./pages/admin/AdminUsers";
 import VerifyEmail from "./pages/auth-page/VerifyEmail";
 import MyOrders from "./pages/my-profile/MyOrders";
 import OrderDetails from "./pages/my-profile/OrderDetails";
+import Invoice from "./pages/my-profile/Invoice";
 import CreateOrder from "./pages/orders/Checkout";
 import ProductUpdatePage from "./pages/admin/AdminUpdateProduct";
 import AdminDiscount from "./pages/admin/AdminDiscount";
@@ -92,6 +93,14 @@ const App = () => {
           element={
             <ProtectedRoute>
               <OrderDetails />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/order/:Id/invoice"
+          element={
+            <ProtectedRoute>
+              <Invoice />
             </ProtectedRoute>
           }
         />

--- a/client/src/pages/my-profile/Invoice.jsx
+++ b/client/src/pages/my-profile/Invoice.jsx
@@ -1,0 +1,382 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams, Link } from "react-router-dom";
+import { motion } from "framer-motion";
+import { CircularProgress, Alert } from "@mui/material";
+import { Download, ArrowLeft } from "lucide-react";
+import { jsPDF } from "jspdf";
+import { getSingleOrder } from "@/store/order-slice/order";
+import MetaData from "../extras/MetaData";
+
+const Invoice = () => {
+  const { Id } = useParams();
+  const dispatch = useDispatch();
+  const { order, loading, error } = useSelector((state) => state.order);
+
+  useEffect(() => {
+    dispatch(getSingleOrder(Id));
+  }, [dispatch, Id]);
+
+  const formatDate = (date) =>
+    date
+      ? new Date(date).toLocaleDateString("en-IN", {
+          day: "2-digit",
+          month: "long",
+          year: "numeric",
+        })
+      : "—";
+
+  // Subtotal = sum of line totals before any order-level discount. Each line
+  // already stores its own totalPrice (unit price * quantity) on the order.
+  const subtotal = (order?.products || []).reduce(
+    (sum, item) => sum + (item.totalPrice || 0),
+    0
+  );
+  const discount = order?.discountAmount || 0;
+
+  const handleDownloadPDF = () => {
+    if (!order) return;
+
+    const doc = new jsPDF();
+    let y = 20;
+
+    // Header
+    doc.setFontSize(20);
+    doc.text("Faith AND Fast", 14, y);
+    y += 8;
+    doc.setFontSize(13);
+    doc.text("Tax Invoice", 14, y);
+    y += 10;
+
+    // Invoice + order meta
+    doc.setFontSize(10);
+    doc.text(`Invoice No: INV-${order._id}`, 14, y);
+    y += 6;
+    doc.text(`Order Date: ${formatDate(order.createdAt)}`, 14, y);
+    y += 6;
+    doc.text(`Order Status: ${order.orderStatus}`, 14, y);
+    y += 10;
+
+    // Billing details
+    doc.setFontSize(12);
+    doc.text("Billed To", 14, y);
+    y += 6;
+    doc.setFontSize(10);
+    doc.text(`${order.user?.name || "Customer"}`, 14, y);
+    y += 6;
+    if (order.user?.email) {
+      doc.text(`${order.user.email}`, 14, y);
+      y += 6;
+    }
+    if (order.address) {
+      doc.text(`${order.address.address_line || ""}`, 14, y);
+      y += 6;
+      doc.text(
+        `${order.address.city || ""}, ${order.address.state || ""} ${
+          order.address.pincode || ""
+        }`,
+        14,
+        y
+      );
+      y += 6;
+      doc.text(`${order.address.country || ""}`, 14, y);
+      y += 6;
+      if (order.address.mobile) {
+        doc.text(`Phone: ${order.address.mobile}`, 14, y);
+        y += 6;
+      }
+    }
+    y += 6;
+
+    // Items header
+    doc.setFontSize(12);
+    doc.text("Items", 14, y);
+    y += 7;
+    doc.setFontSize(9);
+    doc.text("Product", 14, y);
+    doc.text("Qty", 120, y);
+    doc.text("Unit", 140, y);
+    doc.text("Total", 170, y);
+    y += 2;
+    doc.line(14, y, 196, y);
+    y += 6;
+
+    // Items
+    doc.setFontSize(9);
+    order.products.forEach((item) => {
+      const name = item.product?.name || "Product";
+      const truncated = name.length > 50 ? name.slice(0, 47) + "..." : name;
+      doc.text(truncated, 14, y);
+      doc.text(String(item.quantity), 120, y);
+      doc.text(`Rs. ${Number(item.price || 0).toFixed(2)}`, 140, y);
+      doc.text(`Rs. ${Number(item.totalPrice || 0).toFixed(2)}`, 170, y);
+      y += 6;
+      if (item.selectedColor || item.selectedSize) {
+        doc.setFontSize(8);
+        doc.setTextColor(120);
+        const variant = [
+          item.selectedColor ? `Color: ${item.selectedColor}` : "",
+          item.selectedSize ? `Size: ${item.selectedSize}` : "",
+        ]
+          .filter(Boolean)
+          .join("  ");
+        doc.text(variant, 16, y);
+        doc.setTextColor(0);
+        doc.setFontSize(9);
+        y += 6;
+      }
+      if (y > 260) {
+        doc.addPage();
+        y = 20;
+      }
+    });
+
+    y += 2;
+    doc.line(14, y, 196, y);
+    y += 8;
+
+    // Totals
+    doc.setFontSize(10);
+    doc.text(`Subtotal: Rs. ${subtotal.toFixed(2)}`, 130, y);
+    y += 6;
+    if (discount > 0) {
+      doc.text(`Discount: - Rs. ${Number(discount).toFixed(2)}`, 130, y);
+      y += 6;
+      if (order.couponCode) {
+        doc.setFontSize(8);
+        doc.setTextColor(120);
+        doc.text(`Coupon: ${order.couponCode}`, 130, y);
+        doc.setTextColor(0);
+        doc.setFontSize(10);
+        y += 6;
+      }
+    }
+    doc.setFontSize(12);
+    doc.text(`Grand Total: Rs. ${Number(order.totalAmount).toFixed(2)}`, 130, y);
+    y += 10;
+
+    // Payment
+    doc.setFontSize(10);
+    doc.text(`Payment Method: ${order.paymentMethod}`, 14, y);
+    y += 6;
+    doc.text(`Payment Status: ${order.paymentStatus}`, 14, y);
+
+    doc.save(`invoice-${order._id}.pdf`);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen bg-white dark:bg-gray-900">
+        <CircularProgress />
+      </div>
+    );
+  }
+
+  if (error || !order) {
+    return (
+      <div className="min-h-screen bg-white dark:bg-gray-900 py-16 px-4">
+        <Alert severity="info" className="max-w-2xl mx-auto">
+          Invoice not available — order not found.
+        </Alert>
+        <div className="text-center mt-6">
+          <Link
+            to="/my-orders"
+            className="text-yellow-600 dark:text-red-400 hover:underline"
+          >
+            Back to My Orders
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 py-10 px-4 transition-all duration-300">
+      <MetaData title={`Invoice ${order._id} | Faith AND Fast`} />
+
+      <div className="max-w-3xl mx-auto">
+        {/* Action bar — hidden when printing */}
+        <div className="flex items-center justify-between mb-6 print:hidden">
+          <Link
+            to={`/order/${order._id}`}
+            className="flex items-center gap-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
+          >
+            <ArrowLeft className="w-4 h-4" /> Back to Order
+          </Link>
+          <button
+            onClick={handleDownloadPDF}
+            className="flex items-center gap-2 bg-yellow-500 hover:bg-yellow-600 dark:bg-red-600 dark:hover:bg-red-700 text-white px-4 py-2 rounded-lg transition"
+          >
+            <Download className="w-4 h-4" /> Download PDF
+          </button>
+        </div>
+
+        {/* Invoice card */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+          className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 sm:p-10"
+        >
+          {/* Header */}
+          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 border-b border-gray-200 dark:border-gray-700 pb-6">
+            <div>
+              <h1 className="text-3xl font-extrabold text-gray-900 dark:text-white">
+                Faith <span className="text-yellow-500 dark:text-red-500">AND</span> Fast
+              </h1>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                Tax Invoice
+              </p>
+            </div>
+            <div className="sm:text-right text-sm text-gray-600 dark:text-gray-300">
+              <p className="font-mono break-all">
+                <span className="font-semibold">Invoice:</span> INV-{order._id}
+              </p>
+              <p>
+                <span className="font-semibold">Date:</span>{" "}
+                {formatDate(order.createdAt)}
+              </p>
+              <p>
+                <span className="font-semibold">Status:</span>{" "}
+                {order.orderStatus}
+              </p>
+            </div>
+          </div>
+
+          {/* Billing details */}
+          <div className="grid sm:grid-cols-2 gap-6 py-6 border-b border-gray-200 dark:border-gray-700">
+            <div>
+              <h2 className="text-sm font-semibold uppercase text-gray-500 dark:text-gray-400 mb-2">
+                Billed To
+              </h2>
+              <p className="font-medium text-gray-900 dark:text-gray-100">
+                {order.user?.name || "Customer"}
+              </p>
+              {order.user?.email && (
+                <p className="text-sm text-gray-600 dark:text-gray-300">
+                  {order.user.email}
+                </p>
+              )}
+              {order.address && (
+                <div className="text-sm text-gray-600 dark:text-gray-300 mt-2 space-y-0.5">
+                  <p>{order.address.address_line}</p>
+                  <p>
+                    {order.address.city}, {order.address.state}{" "}
+                    {order.address.pincode}
+                  </p>
+                  <p>{order.address.country}</p>
+                  {order.address.mobile && <p>📱 {order.address.mobile}</p>}
+                </div>
+              )}
+            </div>
+            <div className="sm:text-right">
+              <h2 className="text-sm font-semibold uppercase text-gray-500 dark:text-gray-400 mb-2">
+                Payment
+              </h2>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                <span className="font-medium">Method:</span>{" "}
+                {order.paymentMethod}
+              </p>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                <span className="font-medium">Status:</span>{" "}
+                {order.paymentStatus}
+              </p>
+              {order.deliveryDate && (
+                <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
+                  <span className="font-medium">Delivery:</span>{" "}
+                  {formatDate(order.deliveryDate)}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Items table */}
+          <div className="py-6 overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                  <th className="pb-3">Product</th>
+                  <th className="pb-3 text-center">Qty</th>
+                  <th className="pb-3 text-right">Unit Price</th>
+                  <th className="pb-3 text-right">Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {order.products.map((item, idx) => (
+                  <tr
+                    key={idx}
+                    className="border-b border-gray-100 dark:border-gray-700/50"
+                  >
+                    <td className="py-3">
+                      <div className="flex items-center gap-3">
+                        {item.product?.images?.[0]?.url && (
+                          <img
+                            src={item.product.images[0].url}
+                            alt={item.product?.name || "Product"}
+                            className="w-10 h-10 rounded object-cover"
+                          />
+                        )}
+                        <div>
+                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                            {item.product?.name || "Product"}
+                          </p>
+                          {(item.selectedColor || item.selectedSize) && (
+                            <p className="text-xs text-gray-500 dark:text-gray-400">
+                              {item.selectedColor &&
+                                `Color: ${item.selectedColor}`}
+                              {item.selectedColor && item.selectedSize && " · "}
+                              {item.selectedSize && `Size: ${item.selectedSize}`}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="py-3 text-center text-gray-700 dark:text-gray-300">
+                      {item.quantity}
+                    </td>
+                    <td className="py-3 text-right text-gray-700 dark:text-gray-300">
+                      ₹{Number(item.price || 0).toFixed(2)}
+                    </td>
+                    <td className="py-3 text-right font-medium text-gray-900 dark:text-gray-100">
+                      ₹{Number(item.totalPrice || 0).toFixed(2)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Totals */}
+          <div className="flex justify-end">
+            <div className="w-full sm:w-64 space-y-2">
+              <div className="flex justify-between text-sm text-gray-600 dark:text-gray-300">
+                <span>Subtotal</span>
+                <span>₹{subtotal.toFixed(2)}</span>
+              </div>
+              {discount > 0 && (
+                <div className="flex justify-between text-sm text-green-600 dark:text-green-400">
+                  <span>
+                    Discount
+                    {order.couponCode ? ` (${order.couponCode})` : ""}
+                  </span>
+                  <span>- ₹{Number(discount).toFixed(2)}</span>
+                </div>
+              )}
+              <div className="flex justify-between text-lg font-bold text-gray-900 dark:text-white border-t border-gray-200 dark:border-gray-700 pt-2">
+                <span>Grand Total</span>
+                <span>₹{Number(order.totalAmount).toFixed(2)}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="text-center text-xs text-gray-400 dark:text-gray-500 mt-10 pt-6 border-t border-gray-200 dark:border-gray-700">
+            Thank you for shopping with Faith AND Fast.
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+};
+
+export default Invoice;

--- a/client/src/pages/my-profile/OrderDetails.jsx
+++ b/client/src/pages/my-profile/OrderDetails.jsx
@@ -319,7 +319,13 @@ const OrderDetails = () => {
             </motion.div>
           </div>
 
-          <div className="flex justify-center mt-10">
+          <div className="flex flex-wrap justify-center gap-4 mt-10">
+            <Link
+              to={`/order/${order._id}/invoice`}
+              className="bg-yellow-500 hover:bg-yellow-600 dark:bg-red-600 dark:hover:bg-red-700 text-white px-4 py-2 rounded-lg transition duration-300 ease-in-out"
+            >
+              View Invoice
+            </Link>
             {order.orderStatus === "PENDING" && (
               <button
                 className="bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700 text-white px-4 py-2 rounded-lg transition duration-300 ease-in-out disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
## Summary
Implements a dedicated invoice/receipt management system. Users can now access a full invoice page for any order directly from Order Details, view a responsive on-screen invoice with complete billing and product breakdown, and download a richer PDF than the basic receipt already available in My Orders. The existing My Orders receipt is left untouched — this PR adds the genuinely missing pieces: a dedicated page, an Order Details entry point, and richer content.

Closes #50

---

## What was missing (verified against code)

| Requirement | Before this PR |
|---|---|
| Dedicated invoice page (`/order/:Id/invoice`) | ❌ Did not exist |
| Invoice access from Order Details | ❌ No button — only a Cancel button |
| Billing address on invoice | ❌ Absent from basic MyOrders receipt |
| Per-item unit price × qty breakdown | ❌ Absent |
| Discount / coupon breakdown | ❌ Absent |
| Subtotal → discount → grand total | ❌ Absent |
| Responsive on-screen invoice view | ❌ Only PDF existed |

`server/utils/generateReceipt.js` (HTML email receipts) and a basic jsPDF receipt in `MyOrders.jsx` already existed — both are **left completely untouched**. jsPDF `^2.5.2` was already a dependency.

---

## Changes — 3 files (1 new, 2 modified)

### New page — `client/src/pages/my-profile/Invoice.jsx`

A dedicated responsive invoice page at `/order/:Id/invoice`. Reuses the existing `getSingleOrder` thunk (`state.order`) — no new backend endpoint required. Everything the invoice needs is already populated by the existing API (`user` name/email, `address` all fields, `products.product` name/price/images, all order-level fields).

**On-screen invoice includes:**
- Faith AND Fast branded header with invoice number (`INV-{orderId}`) and order date
- Billing section: customer name, email, full delivery address (address_line, city, state, pincode, country, phone)
- Payment section: method, status, delivery date
- Itemized product table: product image, name, color/size variant, quantity, unit price, line total
- Totals breakdown: subtotal → discount (with coupon code label) → grand total
- Branded footer

**PDF download (`handleDownloadPDF`):**
- Same content as the on-screen view: billing address, per-item unit price + qty + line total, variant info, subtotal/discount/grand total, payment details
- Saves as `invoice-{orderId}.pdf`

**UX details:**
- Action bar (Back to Order + Download PDF) hidden on print so the page prints cleanly
- Dark mode fully supported
- Loading + error states handled
- Responsive (stacks on mobile, side-by-side on desktop)

### `client/src/App.jsx` — 2 lines added

Added `Invoice` import and a new protected route:
```jsx
<Route
  path="/order/:Id/invoice"
  element={
    <ProtectedRoute>
      <Invoice />
    </ProtectedRoute>
  }
/>
```
Placed directly after the existing `/order/:Id` route. Uses the same `:Id` param name as the existing route and the same `ProtectedRoute` guard.

### `client/src/pages/my-profile/OrderDetails.jsx` — 7 lines added

Added a "View Invoice" button in the order actions area. Shows for **all orders** (invoices are useful regardless of status), alongside the existing Cancel Order button which is unchanged:
```jsx
<Link
  to={`/order/${order._id}/invoice`}
  className="bg-yellow-500 hover:bg-yellow-600 dark:bg-red-600 ..."
>
  View Invoice
</Link>
```
`Link` was already imported — no new dependencies.

---

## End-to-end wiring verified
- Route `:Id` param → `useParams() { Id }` → `dispatch(getSingleOrder(Id))` → `state.order`
- All rendered fields (`user.name`, `user.email`, `address.address_line/city/state/pincode/country/mobile`, `products[].product.name/price/images`, `totalAmount`, `discountAmount`, `couponCode`, `paymentMethod`, `paymentStatus`, `orderStatus`, `createdAt`, `deliveryDate`) confirmed present in `getSingleOrder` populate
- "Back to Order" link → `/order/${order._id}` matches existing route
- No new backend endpoints, no new dependencies

---

## Checklist
- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] Dedicated invoice page at `/order/:Id/invoice`
- [x] Downloadable PDF with full billing, itemized breakdown, discount
- [x] Invoice access from Order Details ("View Invoice" button)
- [x] Proper order summary, billing details, and product breakdown
- [x] Responsive invoice view for desktop and mobile
- [x] Existing MyOrders receipt and generateReceipt.js untouched
- [x] Protected route — only authenticated users can access invoices
- [x] All data fields confirmed in existing `getSingleOrder` populate — no new backend
- [x] 3 files · 398 insertions · compiles clean