### PR TITLE
fix: improve mobile responsiveness for product listing pages (#34)

### DIFF
--- a/client/src/pages/products/ProductCard.jsx
+++ b/client/src/pages/products/ProductCard.jsx
@@ -16,7 +16,7 @@ const ProductCard = ({ product }) => {
         <img
           src={imageUrl}
           alt={product.name || "Product Image"}
-          className="w-full h-64 object-fit"
+          className="w-full h-40 sm:h-64 object-cover"
           onError={(e) => (e.target.src = "/fallback-image.jpg")}
         />
       </Link>

--- a/client/src/pages/products/Products.jsx
+++ b/client/src/pages/products/Products.jsx
@@ -187,7 +187,7 @@ const Products = () => {
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full ml-3 bg-transparent focus:outline-none text-gray-800 dark:text-gray-100 text-lg"
+            className="w-full ml-3 bg-transparent focus:outline-none text-gray-800 dark:text-gray-100 text-sm sm:text-lg"
             placeholder=" "
           />
           <div className="absolute pointer-events-none ml-10 text-gray-500 dark:text-gray-400">
@@ -410,13 +410,13 @@ const Products = () => {
           {/* Product Grid */}
           <motion.div variants={childVariants} className="flex-1">
             <div className="flex justify-between items-center mb-8">
-              <h2 className="text-3xl font-bold text-gray-800 dark:text-gray-100">
+              <h2 className="text-xl sm:text-3xl font-bold text-gray-800 dark:text-gray-100">
                 All Products
               </h2>
               <select
                 value={sortBy}
                 onChange={(e) => setSortBy(e.target.value)}
-                className="px-4 py-2 bg-white dark:bg-gray-800 rounded-full border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 shadow-sm focus:ring-2 focus:ring-yellow-500 transition duration-200"
+                className="px-2 py-1 sm:px-4 sm:py-2 text-sm sm:text-base bg-white dark:bg-gray-800 rounded-full border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 shadow-sm focus:ring-2 focus:ring-yellow-500 transition duration-200"
               >
                 <option value="relevant">Sort by: Relevant</option>
                 <option value="price-low-high">Price: Low to High</option>
@@ -426,7 +426,7 @@ const Products = () => {
 
             <motion.div
               layout
-              className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6"
             >
               <AnimatePresence>
                 {loading ? (
@@ -475,14 +475,14 @@ const Products = () => {
                         </div>
                       </div>
 
-                      <div className="p-4">
-                        <h3 className="font-semibold text-lg mb-2 line-clamp-2 text-gray-800 dark:text-gray-100">
+                      <div className="p-2 sm:p-4">
+                        <h3 className="font-semibold text-sm sm:text-lg mb-2 line-clamp-2 text-gray-800 dark:text-gray-100">
                           {item.name}
                         </h3>
 
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-2">
-                            <span className="text-xl font-bold text-gray-900 dark:text-gray-100">
+                            <span className="text-base sm:text-xl font-bold text-gray-900 dark:text-gray-100">
                               ₹
                               {(
                                 item.price -


### PR DESCRIPTION
## Related Issue
Fixes #34 

## Description of Changes
Improved mobile responsiveness for product listing pages across 320px, 375px, and 425px screen widths.

## Changes Made

**Products.jsx**
- Search bar text scales down on mobile (`text-sm sm:text-lg`)
- "All Products" heading scales down on mobile (`text-xl sm:text-3xl`)
- Sort dropdown padding and text reduced on mobile
- Product grid changed from `grid-cols-2` to `grid-cols-1` on mobile to prevent card overflow
- Card padding reduced on mobile (`p-2 sm:p-4`)
- Price text scaled down on mobile (`text-base sm:text-xl`)

**ProductCard.jsx**
- Image height reduced on mobile (`h-40 sm:h-64`)
- Fixed `object-fit` to `object-cover` for correct image rendering

## Type of Change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots
Before screenshots taken from live site (faithandfast.vercel.app). After screenshots taken from local development server with fixes applied.

Before: 320px
<img width="1920" height="1032" alt="before-320px png" src="https://github.com/user-attachments/assets/8ec51505-076e-4bbd-a1fd-4fcec9995aed" />
After: 320px
<img width="1920" height="1032" alt="after-320px png" src="https://github.com/user-attachments/assets/f25192c0-f3f4-49ae-b447-4f14fad170bd" />
Before: 375px
<img width="1920" height="1032" alt="before-375px png" src="https://github.com/user-attachments/assets/ebb04723-c51f-43fa-9c6d-1d63f8d82202" />
After: 375px
<img width="1920" height="1032" alt="after-375px png" src="https://github.com/user-attachments/assets/3efaa2f1-57bc-4838-bca8-08acbf2ff943" />
Before: 425px
<img width="1920" height="1032" alt="before-425px png" src="https://github.com/user-attachments/assets/6760d769-cb1f-469b-b931-f0777cdab0a7" />
After: 425px
<img width="1920" height="1032" alt="after-425px png" src="https://github.com/user-attachments/assets/b0c3afdc-71f5-40d5-a63b-283114b3623b" />


## Testing Performed
Tested locally at 320px, 375px, and 425px using Chrome DevTools device toolbar. No horizontal scrolling observed. All elements fit within viewport at all tested widths.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked that there are no merge conflicts
- [x] I have linked the PR to the relevant issue
