### PR TITLE
fix(auth): repair registration → OTP verification flow and harden email delivery (Closes #39)

### DIFF
--- a/client/src/pages/auth-page/Signup.jsx
+++ b/client/src/pages/auth-page/Signup.jsx
@@ -25,9 +25,23 @@ const SignUp = () => {
   useEffect(() => {}, [user, loading, navigate, dispatch]);
   const handleSubmit = async (e) => {
     e.preventDefault();
-    dispatch(signupUser({ name, email, password }));
-    toast.success("Successfully Register User");
-    navigate("/login");
+
+    if (!name || !email || !password) {
+      toast.error("Please fill all required fields");
+      return;
+    }
+
+    try {
+      // Wait for the actual result before deciding success vs failure.
+      await dispatch(signupUser({ name, email, password })).unwrap();
+      toast.success(
+        "Registration successful! Please check your email for the OTP."
+      );
+      // Go straight to OTP entry — the account is not verified yet.
+      navigate("/verify-email");
+    } catch {
+      // Failure message is surfaced by the error effect below.
+    }
   };
 
   useEffect(() => {

--- a/client/src/store/auth-slice/user.js
+++ b/client/src/store/auth-slice/user.js
@@ -51,8 +51,10 @@ export const signupUser = createAsyncThunk(
         }
       );
 
-      if (!response.data || !response.data.token || !response.data.user) {
-        throw new Error("Invalid response from server");
+      if (!response.data || !response.data.success) {
+        return rejectWithValue(
+          response.data || { message: "Registration failed. Please try again." }
+        );
       }
 
       return response.data;
@@ -340,9 +342,12 @@ const authSlice = createSlice({
       })
       .addCase(signupUser.fulfilled, (state, action) => {
         state.loading = false;
-        state.user = action.payload.user;
-        state.token = action.payload.token;
-        state.isAuthenticated = true;
+        // Registration returns the created user under `data` and does NOT issue a
+        // token (the account is only logged in after email verification + login).
+        // Store the user so the verify-email step knows which address to confirm,
+        // but keep the session unauthenticated.
+        state.user = action.payload.data || null;
+        state.success = true;
       })
       .addCase(signupUser.rejected, (state, action) => {
         state.loading = false;

--- a/docs/EMAIL_OTP_SETUP.md
+++ b/docs/EMAIL_OTP_SETUP.md
@@ -1,0 +1,65 @@
+# Email & OTP Setup (Brevo)
+
+Faith AND Fast uses [Brevo](https://www.brevo.com/) (formerly Sendinblue) to send
+transactional emails: the registration OTP, password-reset OTP, and account-status
+notifications. This guide covers the configuration required for reliable delivery.
+
+## 1. Required environment variables
+
+Add these to your server `.env` file:
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `BREVO_API_KEY` | **Yes** | — | Brevo transactional API key (`xkeysib-...`). Without it, all OTP emails fail. |
+| `BREVO_SENDER_EMAIL` | No | `support@faithandfast.com` | The "from" address. **Must be a verified sender in Brevo** (see step 2). |
+| `BREVO_SENDER_NAME` | No | `Faith AND Fast` | Display name shown to recipients. |
+| `EMAIL_MAX_RETRIES` | No | `2` | How many times to attempt each send before giving up. |
+| `EMAIL_RETRY_DELAY_MS` | No | `1000` | Delay (ms) between retry attempts. |
+
+On startup, the server logs a clear error if `BREVO_API_KEY` is missing, so
+misconfiguration is caught immediately instead of failing silently at registration.
+
+## 2. Verify your sender in Brevo
+
+Brevo rejects emails sent from unverified senders — this is the most common cause of
+"OTP not received."
+
+1. Sign in to Brevo → **Settings → Senders, Domains & Dedicated IPs**.
+2. Add and verify the email address you set as `BREVO_SENDER_EMAIL` (or verify your
+   whole sending domain via DNS for best deliverability).
+3. Confirm the status shows **Verified** before going live.
+
+## 3. Get your API key
+
+Brevo → **Settings → SMTP & API → API Keys → Generate a new API key**. Copy it into
+`BREVO_API_KEY`. Treat it as a secret — never commit it.
+
+## 4. How the OTP flow works
+
+**Registration**
+1. User submits the signup form.
+2. The server generates a 6-digit OTP (15-minute expiry), emails it, and creates the
+   account with `verifyEmail: false`. No login token is issued yet.
+3. The client routes the user to `/verify-email`.
+4. User enters the OTP; on success `verifyEmail` is set to `true` and they can log in.
+
+**Password reset** uses the same email service with a separate 10-minute OTP.
+
+## 5. Reliability & logging
+
+- Each send is retried up to `EMAIL_MAX_RETRIES` times on transient failure.
+- Every attempt logs the recipient, subject, and (on failure) the underlying Brevo
+  error detail, e.g.:
+  ```
+  [email] Sent "Verify Your Email - Faith AND Fast" to user@example.com (attempt 1).
+  [email] Failed to send "..." to user@example.com (attempt 1/2): <Brevo error>
+  ```
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Startup log: `BREVO_API_KEY is not set` | Missing env var | Set `BREVO_API_KEY` and restart |
+| `401`/unauthorized in email logs | Invalid API key | Regenerate the key in Brevo |
+| Sends succeed but mail never arrives | Unverified sender | Verify `BREVO_SENDER_EMAIL` in Brevo (step 2) |
+| OTP arrives but verification fails | OTP expired (15 min) | Use **Resend OTP** on the verify page |

--- a/server/config/sendEmail.js
+++ b/server/config/sendEmail.js
@@ -2,26 +2,90 @@ import Sib from "sib-api-v3-sdk";
 import dotenv from "dotenv";
 dotenv.config();
 
+// Sender + retry behaviour are configurable via environment variables, with
+// sensible defaults so existing deployments keep working unchanged.
+const SENDER_EMAIL = process.env.BREVO_SENDER_EMAIL || "support@faithandfast.com";
+const SENDER_NAME = process.env.BREVO_SENDER_NAME || "Faith AND Fast";
+const MAX_RETRIES = Number(process.env.EMAIL_MAX_RETRIES) || 2;
+const RETRY_DELAY_MS = Number(process.env.EMAIL_RETRY_DELAY_MS) || 1000;
+
+// Validate required configuration at startup so a missing key fails loudly here
+// instead of silently breaking OTP delivery when a user tries to register.
+if (!process.env.BREVO_API_KEY) {
+  console.error(
+    "[email] BREVO_API_KEY is not set. Email verification and password-reset " +
+      "emails will fail. Set BREVO_API_KEY in your environment " +
+      "(see docs/EMAIL_OTP_SETUP.md)."
+  );
+}
+
 const client = Sib.ApiClient.instance;
 const apiKey = client.authentications["api-key"];
 apiKey.apiKey = process.env.BREVO_API_KEY;
 
-const sendEmail = async ({ sendTo, subject, html }) => {
-  try {
-    const tranEmailApi = new Sib.TransactionalEmailsApi();
-    await tranEmailApi.sendTransacEmail({
-      sender: { email: "support@faithandfast.com", name: "Faith AND Fast" },
-      to: [{ email: sendTo }],
-      subject: subject,
-      htmlContent: html,
-    });
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-    console.log("Email sent successfully!");
-    return true;
-  } catch (error) {
-    console.error("Error sending email:", error);
+/**
+ * Sends a transactional email through Brevo.
+ *
+ * Returns `true` on success and `false` on failure — callers (registerUser,
+ * verifyEmailOtp, resendOtp, ...) rely on this boolean contract.
+ *
+ * Transient failures are retried, and every failed attempt is logged with the
+ * recipient, subject, and the underlying Brevo error detail so delivery
+ * problems are visible in server logs instead of disappearing silently.
+ */
+const sendEmail = async ({ sendTo, subject, html }) => {
+  if (!process.env.BREVO_API_KEY) {
+    console.error(
+      `[email] Cannot send "${subject}" to ${sendTo}: BREVO_API_KEY is missing.`
+    );
     return false;
   }
+
+  if (!sendTo) {
+    console.error(`[email] Cannot send "${subject}": no recipient provided.`);
+    return false;
+  }
+
+  const tranEmailApi = new Sib.TransactionalEmailsApi();
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      await tranEmailApi.sendTransacEmail({
+        sender: { email: SENDER_EMAIL, name: SENDER_NAME },
+        to: [{ email: sendTo }],
+        subject,
+        htmlContent: html,
+      });
+
+      console.log(
+        `[email] Sent "${subject}" to ${sendTo} (attempt ${attempt}).`
+      );
+      return true;
+    } catch (error) {
+      // Brevo surfaces useful detail on error.response.body / .text.
+      const detail =
+        error?.response?.body ||
+        error?.response?.text ||
+        error?.message ||
+        error;
+      console.error(
+        `[email] Failed to send "${subject}" to ${sendTo} ` +
+          `(attempt ${attempt}/${MAX_RETRIES}):`,
+        detail
+      );
+
+      if (attempt < MAX_RETRIES) {
+        await delay(RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  console.error(
+    `[email] Giving up on "${subject}" to ${sendTo} after ${MAX_RETRIES} attempts.`
+  );
+  return false;
 };
 
 export default sendEmail;


### PR DESCRIPTION
## Summary
Fixes OTP email delivery failures during user registration. The issue had two independent root causes: a broken frontend chain that prevented verification even when the OTP email arrived correctly, and a delivery pipeline with no configuration validation, no retries, and no useful logging. Both are addressed, along with setup documentation covering the infrastructure and environment points raised in the issue.

Closes #39

---

## Root cause analysis (verified against the codebase)

### A — Frontend chain prevented verification even when the email arrived

**1. `signupUser` thunk rejected every successful registration**
The thunk checked for `response.data.token` and `response.data.user`, but `registerUser` returns `{ message, success, data: savedUser }` — no token, no `user` field (registration intentionally does not log the user in). This check therefore threw `"Invalid response from server"` on every 201 response, treating every successful registration as a failure.

**2. `state.auth.user` was never set after signup**
Because of (1), the `fulfilled` case never ran. Even without the thunk bug, the `fulfilled` reducer read `action.payload.user` (which would have been undefined — the field is `data`, not `user`) and set `isAuthenticated = true` with no token — incorrectly marking an unverified session as authenticated.

**3. The OTP verify page had no email to send**
`VerifyEmail.jsx` reads the address to confirm from `state.auth.user?.email`. Since that was never populated, the page called `verifyEmailOtp({ email: undefined, otp })`. The backend did `UserModel.findOne({ email: undefined })` → `"Email not registered."` — verification was impossible regardless of whether the OTP email was delivered.

**4. `Signup.jsx` always showed success regardless of outcome**
`handleSubmit` dispatched signup without awaiting, showed `"Successfully Register User"` unconditionally, and navigated to `/login` — so failures appeared as successes and the user was never routed to the OTP entry page at `/verify-email`.

### B — Email delivery pipeline had no resilience or observability

- **No startup validation** of `BREVO_API_KEY` — a missing key only failed silently the moment a user tried to register, with no actionable log entry.
- **No retry** on transient Brevo failures — a single network hiccup meant the OTP was never sent.
- **Failures swallowed** by a generic `console.error("Error sending email:", error)` with no recipient, subject, or Brevo error detail — impossible to diagnose "OTP not received" from logs.

> **Note on the OTP comparison:** `generatedOtp()` returns a number, but `userModel.login_otp` is `type: String`, so Mongoose casts the value on save and the frontend sends a string — the strict `!==` comparison works correctly. No fix was needed or claimed there.

---

## Changes — 4 files

### `client/src/store/auth-slice/user.js`

**`signupUser` thunk:**
Replaced the invalid `token`/`user` response check with a `response.data.success` check. Failures now call `rejectWithValue` with the server payload so error messages reach the UI.

**`signupUser.fulfilled` reducer:**
Stores the created user from `action.payload.data` so `VerifyEmail.jsx` has the email address it needs. Does **not** set `token` or `isAuthenticated` — registration is not a login; those are set only after email verification and an explicit login.

### `client/src/pages/auth-page/Signup.jsx`

`handleSubmit` now:
- Validates that name, email, and password are filled before dispatching
- `await`s `.unwrap()` so success and failure are correctly distinguished
- Shows `"Registration successful! Please check your email for the OTP."` only on actual success
- Navigates to `/verify-email` (the OTP entry page) instead of `/login`
- Lets the existing error `useEffect` surface real failure messages from the server

### `server/config/sendEmail.js`

- Validates `BREVO_API_KEY` at module load and per-send, with a clear actionable error if it is missing
- Retries transient failures up to `EMAIL_MAX_RETRIES` times (default 2) with a configurable delay (`EMAIL_RETRY_DELAY_MS`, default 1000ms)
- Logs recipient, subject, attempt number, and the underlying Brevo error detail on every failure
- Sender address and name are now configurable via `BREVO_SENDER_EMAIL` / `BREVO_SENDER_NAME` (defaults unchanged: `support@faithandfast.com` / `Faith AND Fast`)
- **Preserves the boolean return contract exactly** — the three callers in `userController.js` that rely on `if (!emailResponse)` are unaffected

### `docs/EMAIL_OTP_SETUP.md` *(new)*

Covers all the infrastructure/environment points from the issue:
- Required env vars and their defaults (table)
- Brevo sender verification steps (the most common cause of "OTP not received")
- How to obtain and set the API key
- The full OTP flow for registration and password reset
- Retry/logging behaviour
- Troubleshooting table (missing key, invalid key, unverified sender, expired OTP)

---

## Resulting flow (end to end)

1. User fills the signup form and submits.
2. Request reaches `registerUser` → OTP generated, emailed with retry + detailed logging, account created with `verifyEmail: false`. No token issued.
3. Frontend receives `success: true` → routes user to `/verify-email` with `state.auth.user.email` populated.
4. User enters the 6-digit OTP from the email.
5. Backend compares strings (both sides), checks expiry, sets `verifyEmail: true`.
6. `VerifyEmail.jsx` detects `verifyEmail: true` → navigates to the redirect target.
7. User logs in normally. Failed deliveries now appear in server logs with full context.

---

## Verification

| Check | Result |
|---|---|
| All 3 code files compile clean (esbuild / `node --check`) | ✅ |
| `user.js` diff: 2 surgical edits, no other lines touched | ✅ |
| `Signup.jsx` diff: 1 surgical edit to `handleSubmit`, nothing else | ✅ |
| `sendEmail.js` boolean return preserved — 3 callers unaffected | ✅ |
| No changes to `userController.js` — no conflict with #55 | ✅ |
| No new npm dependencies | ✅ |
| 4 files · 169 net insertions | ✅ |

---

## Checklist
- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] Registration no longer falsely rejected on every success
- [x] Verify-email page receives the correct email address
- [x] End-to-end registration → OTP → verification flow works
- [x] Email delivery validated at startup, retried on failure, logged with detail
- [x] Meaningful error messages surfaced to the user on failure
- [x] Infrastructure / env / sender-verification documentation added