### PR TITLE
feat(auth): implement production-ready password recovery flow (Closes #55)

### DIFF
--- a/client/src/pages/auth-page/ForgotPassword.jsx
+++ b/client/src/pages/auth-page/ForgotPassword.jsx
@@ -1,74 +1,147 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 import { Email, Lock } from "@mui/icons-material";
+import { toast } from "react-toastify";
+import {
+  sendResetOtp,
+  verifyResetOtp,
+  clearPasswordState,
+  clearPasswordMessages,
+} from "@/store/auth-slice/updatePasswordSlice";
+import MetaData from "../extras/MetaData";
 
 const ForgotPassword = () => {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [emailSubmitted, setEmailSubmitted] = useState(false);
-  const [sentPassword] = useState("123456"); // Mock password for validation
+  const [email, setLocalEmail] = useState("");
+  const [otp, setOtp] = useState("");
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
-  const handleEmailSubmit = () => {
-    setEmailSubmitted(true);
+  const { loading, error, message, otpSent, otpVerified } = useSelector(
+    (state) => state.updatePassword
+  );
+
+  // Start from a clean slate whenever the page mounts.
+  useEffect(() => {
+    dispatch(clearPasswordState());
+  }, [dispatch]);
+
+  // Surface server/validation messages.
+  useEffect(() => {
+    if (error) {
+      toast.error(error);
+      dispatch(clearPasswordMessages());
+    }
+  }, [error, dispatch]);
+
+  useEffect(() => {
+    if (message) {
+      toast.success(message);
+      dispatch(clearPasswordMessages());
+    }
+  }, [message, dispatch]);
+
+  // Once the OTP is verified, move to the reset step carrying the email.
+  useEffect(() => {
+    if (otpVerified) {
+      navigate("/reset-password", { state: { email } });
+    }
+  }, [otpVerified, navigate, email]);
+
+  const handleEmailSubmit = (e) => {
+    e.preventDefault();
+    if (!email) {
+      toast.error("Please enter your email");
+      return;
+    }
+    dispatch(sendResetOtp(email));
   };
 
-  const handlePasswordSubmit = () => {
-    if (password === sentPassword) {
-      navigate("/reset-password");
-    } else {
-      alert("Incorrect password. Please try again.");
+  const handleOtpSubmit = (e) => {
+    e.preventDefault();
+    if (otp.length !== 6) {
+      toast.error("OTP must be 6 digits");
+      return;
+    }
+    dispatch(verifyResetOtp({ email, otp }));
+  };
+
+  const handleResend = () => {
+    if (email) {
+      dispatch(sendResetOtp(email));
     }
   };
 
   return (
-    <div className="flex justify-center items-center h-screen bg-white text-black dark:bg-gray-800 dark:text-white">
-      <div className="w-96  p-6 rounded-lg shadow-md text-center bg-white text-black dark:bg-gray-900 dark:text-white">
-        <h2 className="text-2xl font-bold mb-4 bg-white text-black dark:bg-gray-900 dark:text-white">Forgot Password</h2>
-        {!emailSubmitted ? (
-          <>
-            <p className="dark:text-white dark:bg-gray-900 mb-4 bg-white text-black ">Enter your registered email to receive a temporary password.</p>
+    <div className="flex justify-center items-center min-h-screen bg-white text-black dark:bg-gray-800 dark:text-white">
+      <MetaData title="Forgot Password | Faith AND Fast" />
+      <div className="w-96 p-6 rounded-lg shadow-md text-center bg-white text-black dark:bg-gray-900 dark:text-white">
+        <h2 className="text-2xl font-bold mb-4">Forgot Password</h2>
+
+        {!otpSent ? (
+          <form onSubmit={handleEmailSubmit}>
+            <p className="mb-4">
+              Enter your registered email to receive a verification OTP.
+            </p>
             <div className="mb-4">
-              <div className="flex items-center border border-gray-300 rounded-lg  bg-white text-black dark:bg-gray-900 dark:text-white p-2">
-                <Email className=" bg-white text-black dark:bg-gray-900 dark:text-white" />
+              <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-lg bg-white text-black dark:bg-gray-900 dark:text-white p-2">
+                <Email />
                 <input
                   type="email"
                   placeholder="Enter your email"
                   value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="ml-2 w-full outline-none bg-white text-black dark:bg-gray-900 dark:text-white"
+                  onChange={(e) => setLocalEmail(e.target.value)}
+                  className="ml-2 w-full outline-none bg-transparent"
+                  required
                 />
               </div>
             </div>
             <button
-              className="w-full bg-yellow-500 text-white font-bold py-2 rounded-lg hover:bg-yellow-600"
-              onClick={handleEmailSubmit}
+              type="submit"
+              disabled={loading}
+              className="w-full bg-yellow-500 dark:bg-red-600 text-white font-bold py-2 rounded-lg hover:bg-yellow-600 dark:hover:bg-red-700 transition disabled:opacity-60"
             >
-              Send Code
+              {loading ? "Sending..." : "Send OTP"}
             </button>
-          </>
+          </form>
         ) : (
-          <>
-            <p className="text-gray-600 mb-4">Enter the temporary password sent to your email.</p>
+          <form onSubmit={handleOtpSubmit}>
+            <p className="mb-4">
+              Enter the 6-digit OTP sent to <strong>{email}</strong>.
+            </p>
             <div className="mb-4">
-              <div className="flex items-center border border-gray-300 rounded-lg bg-gray-100 p-2">
-                <Lock className="text-gray-500" />
+              <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-lg bg-white text-black dark:bg-gray-900 dark:text-white p-2">
+                <Lock />
                 <input
-                  type="password"
-                  placeholder="Enter the code"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="ml-2 w-full bg-transparent outline-none"
+                  type="text"
+                  inputMode="numeric"
+                  maxLength="6"
+                  placeholder="Enter the OTP"
+                  value={otp}
+                  onChange={(e) =>
+                    setOtp(e.target.value.replace(/\D/g, "").slice(0, 6))
+                  }
+                  className="ml-2 w-full outline-none bg-transparent text-center tracking-widest font-semibold"
+                  required
                 />
               </div>
             </div>
             <button
-              className="w-full bg-yellow-500 text-white font-bold py-2 rounded-lg hover:bg-yellow-600"
-              onClick={handlePasswordSubmit}
+              type="submit"
+              disabled={loading}
+              className="w-full bg-yellow-500 dark:bg-red-600 text-white font-bold py-2 rounded-lg hover:bg-yellow-600 dark:hover:bg-red-700 transition disabled:opacity-60"
             >
-              Verify and Reset Password
+              {loading ? "Verifying..." : "Verify OTP"}
             </button>
-          </>
+            <button
+              type="button"
+              onClick={handleResend}
+              disabled={loading}
+              className="mt-4 text-yellow-500 dark:text-red-500 font-bold hover:underline disabled:opacity-60"
+            >
+              Resend OTP
+            </button>
+          </form>
         )}
       </div>
     </div>

--- a/client/src/pages/auth-page/ResetPassword.jsx
+++ b/client/src/pages/auth-page/ResetPassword.jsx
@@ -1,56 +1,128 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 import { Lock } from "@mui/icons-material";
+import { toast } from "react-toastify";
+import {
+  updatePassword,
+  clearPasswordState,
+  clearPasswordMessages,
+} from "@/store/auth-slice/updatePasswordSlice";
+import MetaData from "../extras/MetaData";
 
 const ResetPassword = () => {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const navigate = useNavigate();
+  const location = useLocation();
+  const dispatch = useDispatch();
 
-  const handleReset = () => {
-    if (password === confirmPassword) {
-      alert("Password reset successful!");
-    } else {
-      alert("Passwords do not match!");
+  const {
+    loading,
+    success,
+    error,
+    email: storedEmail,
+  } = useSelector((state) => state.updatePassword);
+
+  // Email comes from the verified forgot-password step (router state first,
+  // redux as fallback).
+  const email = location.state?.email || storedEmail;
+
+  // Guard: this page is only reachable after OTP verification. Without an email
+  // there is nothing to reset, so send the user back to start the flow.
+  useEffect(() => {
+    if (!email) {
+      toast.error("Please verify your email before resetting your password.");
+      navigate("/forgot-password");
     }
+  }, [email, navigate]);
+
+  // Surface errors.
+  useEffect(() => {
+    if (error) {
+      toast.error(error);
+      dispatch(clearPasswordMessages());
+    }
+  }, [error, dispatch]);
+
+  // On success, notify and redirect to login.
+  useEffect(() => {
+    if (success) {
+      toast.success("Password reset successful! Please log in.");
+      dispatch(clearPasswordState());
+      navigate("/login");
+    }
+  }, [success, navigate, dispatch]);
+
+  const handleReset = (e) => {
+    e.preventDefault();
+
+    if (!password || !confirmPassword) {
+      toast.error("Please fill in both password fields");
+      return;
+    }
+    if (password.length < 6) {
+      toast.error("Password must be at least 6 characters long");
+      return;
+    }
+    if (password !== confirmPassword) {
+      toast.error("Passwords do not match!");
+      return;
+    }
+
+    dispatch(
+      updatePassword({ email, newPassword: password, confirmPassword })
+    );
   };
 
   return (
-    <div className="flex justify-center items-center h-screen bg-gray-100 dark:bg-gray-900">
+    <div className="flex justify-center items-center min-h-screen bg-gray-100 dark:bg-gray-900">
+      <MetaData title="Reset Password | Faith AND Fast" />
       <div className="w-96 bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md text-center">
-        <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100">Reset Password</h2>
-        <p className="text-gray-600 dark:text-gray-300 mb-4">Enter your new password below.</p>
-
-        <div className="mb-4">
-          <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-100 dark:bg-gray-700 p-2">
-            <Lock className="text-gray-500 dark:text-gray-400" />
-            <input
-              type="password"
-              placeholder="Enter new password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="ml-2 w-full bg-transparent outline-none text-gray-900 dark:text-gray-100"
-            />
-          </div>
-        </div>
-
-        <div className="mb-4">
-          <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-100 dark:bg-gray-700 p-2">
-            <Lock className="text-gray-500 dark:text-gray-400" />
-            <input
-              type="password"
-              placeholder="Confirm new password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              className="ml-2 w-full bg-transparent outline-none text-gray-900 dark:text-gray-100"
-            />
-          </div>
-        </div>
-
-        <button
-          className="w-full bg-yellow-500 text-white font-bold py-2 rounded-lg hover:bg-yellow-600"
-          onClick={handleReset}
-        >
+        <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100">
           Reset Password
-        </button>
+        </h2>
+        <p className="text-gray-600 dark:text-gray-300 mb-4">
+          Enter your new password below.
+        </p>
+
+        <form onSubmit={handleReset}>
+          <div className="mb-4">
+            <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-100 dark:bg-gray-700 p-2">
+              <Lock className="text-gray-500 dark:text-gray-400" />
+              <input
+                type="password"
+                placeholder="Enter new password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="ml-2 w-full bg-transparent outline-none text-gray-900 dark:text-gray-100"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-100 dark:bg-gray-700 p-2">
+              <Lock className="text-gray-500 dark:text-gray-400" />
+              <input
+                type="password"
+                placeholder="Confirm new password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="ml-2 w-full bg-transparent outline-none text-gray-900 dark:text-gray-100"
+                required
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-yellow-500 dark:bg-red-600 text-white font-bold py-2 rounded-lg hover:bg-yellow-600 dark:hover:bg-red-700 transition disabled:opacity-60"
+          >
+            {loading ? "Resetting..." : "Reset Password"}
+          </button>
+        </form>
       </div>
     </div>
   );

--- a/client/src/store/auth-slice/updatePasswordSlice.js
+++ b/client/src/store/auth-slice/updatePasswordSlice.js
@@ -1,37 +1,128 @@
 import axiosInstance from "@/api";
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 
-export const updatePassword = createAsyncThunk(
-  "updatePassword/reset",
-  async (userData, { rejectWithValue }) => {
+// Step 1 — request a password-reset OTP for the given email.
+export const sendResetOtp = createAsyncThunk(
+  "updatePassword/sendResetOtp",
+  async (email, { rejectWithValue }) => {
     try {
-      const response = await axiosInstance.put("/api/user/reset-password", userData);
-      return response.data;
+      const response = await axiosInstance.put("/api/user/forgot-password", {
+        email,
+      });
+      return { ...response.data, email };
     } catch (error) {
-      return rejectWithValue(error.response?.data?.message || "Something went wrong.");
+      return rejectWithValue(
+        error.response?.data?.message || "Failed to send reset OTP."
+      );
     }
   }
 );
 
+// Step 2 — verify the OTP the user received by email.
+export const verifyResetOtp = createAsyncThunk(
+  "updatePassword/verifyResetOtp",
+  async ({ email, otp }, { rejectWithValue }) => {
+    try {
+      const response = await axiosInstance.put("/api/user/verify-otp", {
+        email,
+        otp,
+      });
+      return { ...response.data, email };
+    } catch (error) {
+      return rejectWithValue(
+        error.response?.data?.message || "OTP verification failed."
+      );
+    }
+  }
+);
+
+// Step 3 — set the new password (requires a verified OTP for this email).
+export const updatePassword = createAsyncThunk(
+  "updatePassword/reset",
+  async (userData, { rejectWithValue }) => {
+    try {
+      const response = await axiosInstance.put(
+        "/api/user/reset-password",
+        userData
+      );
+      return response.data;
+    } catch (error) {
+      return rejectWithValue(
+        error.response?.data?.message || "Something went wrong."
+      );
+    }
+  }
+);
+
+const initialState = {
+  loading: false,
+  success: false, // password successfully reset
+  error: null,
+  message: null,
+  otpSent: false, // step 1 complete
+  otpVerified: false, // step 2 complete
+  email: "",
+};
+
 const updatePasswordSlice = createSlice({
   name: "updatePassword",
-  initialState: {
-    loading: false,
-    success: false,
-    error: null,
+  initialState,
+  reducers: {
+    // Reset the whole recovery flow (call on mount / after completion).
+    clearPasswordState: () => ({ ...initialState }),
+    // Clear only transient messages without losing flow progress.
+    clearPasswordMessages: (state) => {
+      state.error = null;
+      state.message = null;
+    },
   },
-  reducers: {},
   extraReducers: (builder) => {
     builder
+      // Step 1 — send OTP
+      .addCase(sendResetOtp.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+        state.message = null;
+      })
+      .addCase(sendResetOtp.fulfilled, (state, action) => {
+        state.loading = false;
+        state.otpSent = true;
+        state.email = action.payload.email;
+        state.message = action.payload.message;
+      })
+      .addCase(sendResetOtp.rejected, (state, action) => {
+        state.loading = false;
+        state.otpSent = false;
+        state.error = action.payload;
+      })
+      // Step 2 — verify OTP
+      .addCase(verifyResetOtp.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+        state.message = null;
+      })
+      .addCase(verifyResetOtp.fulfilled, (state, action) => {
+        state.loading = false;
+        state.otpVerified = true;
+        state.email = action.payload.email;
+        state.message = action.payload.message;
+      })
+      .addCase(verifyResetOtp.rejected, (state, action) => {
+        state.loading = false;
+        state.otpVerified = false;
+        state.error = action.payload;
+      })
+      // Step 3 — reset password
       .addCase(updatePassword.pending, (state) => {
         state.loading = true;
         state.success = false;
         state.error = null;
       })
-      .addCase(updatePassword.fulfilled, (state) => {
+      .addCase(updatePassword.fulfilled, (state, action) => {
         state.loading = false;
         state.success = true;
         state.error = null;
+        state.message = action.payload?.message || "Password updated.";
       })
       .addCase(updatePassword.rejected, (state, action) => {
         state.loading = false;
@@ -41,4 +132,6 @@ const updatePasswordSlice = createSlice({
   },
 });
 
+export const { clearPasswordState, clearPasswordMessages } =
+  updatePasswordSlice.actions;
 export default updatePasswordSlice.reducer;

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -355,7 +355,7 @@ export const forgotPassword = catchAsyncErrors(async (req, res) => {
       });
     }
 
-    await sendEmail({
+    const emailResponse = await sendEmail({
       sendTo: email,
       subject: "Forgot password from Faith AND Fast",
       html: forgotPasswordTemplate({
@@ -363,6 +363,14 @@ export const forgotPassword = catchAsyncErrors(async (req, res) => {
         otp: otp,
       }),
     });
+
+    if (!emailResponse) {
+      return res.status(500).json({
+        message: "Failed to send password reset email. Please try again later.",
+        error: true,
+        success: false,
+      });
+    }
 
     return res.json({
       message:


### PR DESCRIPTION
## Summary
Implements a fully functional, production-ready password recovery flow. The backend (forgot-password → verify-otp → reset-password) was already complete and correct. The entire frontend was a non-functional mock that never called the API — hardcoded passwords, no OTP emails sent, no actual password updates. This PR wires all three frontend steps to the three existing backend endpoints, with proper validation, error surfacing, loading states, and success redirects at every step.

Closes #55

---

## Root cause analysis (verified against the codebase)

### `ForgotPassword.jsx` — entirely mocked, never touched the backend
- `handleEmailSubmit` only set a local `emailSubmitted` flag — it **never called `/api/user/forgot-password`**, so no OTP was ever sent to the user.
- After "sending", it validated the entered value against `const [sentPassword] = useState("123456")` — a hardcoded mock — instead of calling `/api/user/verify-otp`.
- On "success" it navigated to `/reset-password` without passing the email, so the reset page had no address to work with.

### `ResetPassword.jsx` — entirely mocked, never updated the password
- `handleReset` only checked `password === confirmPassword` and called `alert("Password reset successful!")`.
- It **never dispatched `updatePassword`** and never called `/api/user/reset-password`, so the password was never actually changed in the database.
- It had no email to send (backend `resetPassword` requires `{ email, newPassword, confirmPassword }`).

### `updatePasswordSlice.js` — thunk existed but nothing dispatched it
- The `updatePassword` thunk (step 3) was correctly implemented but nothing in the UI called it.
- There were no thunks for the OTP-send (step 1) or OTP-verify (step 2) steps.

### `server/controllers/userController.js` — `forgotPassword` ignored email-send failures
- The controller sent the OTP email but did not check the `sendEmail` boolean result — a delivery failure still returned `"OTP sent successfully"`, leaving the user waiting for an email that never arrived.

---

## Changes — 4 files

### `client/src/store/auth-slice/updatePasswordSlice.js`

Added two new thunks for the missing steps:
- `sendResetOtp(email)` → `PUT /api/user/forgot-password` — requests the OTP email
- `verifyResetOtp({ email, otp })` → `PUT /api/user/verify-otp` — verifies the entered OTP

Kept the existing `updatePassword({ email, newPassword, confirmPassword })` → `PUT /api/user/reset-password` with the **identical signature** — the profile "Update Password" page (`UpdatePassword.jsx`) still works with no changes.

Added flow state fields: `otpSent`, `otpVerified`, `email`, `message`, and two reset actions — `clearPasswordState` (full reset on mount) and `clearPasswordMessages` (clears transient toasts without losing flow progress).

All existing fields (`loading`, `success`, `error`) preserved with identical semantics.

### `client/src/pages/auth-page/ForgotPassword.jsx` (rewrite)

Real 2-step flow wired to the backend:

**Step 1 — Email entry:**
- Dispatches `sendResetOtp(email)` → backend sends the real OTP email
- Shows `loading` state on the button; surfaces server errors via toast
- On success (`otpSent = true`) advances to the OTP entry step

**Step 2 — OTP entry:**
- Numeric-only input (`inputMode="numeric"`, strips non-digits), maxLength 6
- Dispatches `verifyResetOtp({ email, otp })` → backend verifies against `forgot_password_otp`
- "Resend OTP" button re-dispatches step 1
- On success (`otpVerified = true`) navigates to `/reset-password` carrying the verified email via router state
- `clearPasswordState` called on mount so re-entering the page starts clean

### `client/src/pages/auth-page/ResetPassword.jsx` (rewrite)

Real password reset wired to the backend:
- Reads the verified email from `location.state.email` (router) with `state.updatePassword.email` (redux) as fallback
- **Guard:** if no email is present, toasts an error and redirects to `/forgot-password` — prevents direct URL access skipping verification
- Client-side validation: both fields required, minimum 6 characters (mirrors backend), passwords must match — clear error messages before the API call
- Dispatches `updatePassword({ email, newPassword, confirmPassword })`
- On `success`: toast + `clearPasswordState` + `navigate("/login")`
- On `error`: server message surfaced via toast
- Loading state on the submit button while the thunk runs

### `server/controllers/userController.js`

One surgical change in `forgotPassword`: capture the `sendEmail` return value and return a 500 with a clear actionable message if delivery fails — making it symmetric with `registerUser`. Exactly 8 lines added, nothing else touched.

---

## End-to-end flow (after this PR)

| Step | User action | What happens |
|---|---|---|
| 1 | Enters email on `/forgot-password` | `sendResetOtp` → `PUT /forgot-password` → OTP emailed |
| 2 | Enters 6-digit OTP | `verifyResetOtp` → `PUT /verify-otp` → verified; routed to `/reset-password` |
| 3 | Enters + confirms new password | `updatePassword` → `PUT /reset-password` → password updated in DB |
| 4 | Success | Toast + redirect to `/login` |
| Any failure | Server or validation error | Clear toast message; user stays on current step |

---

## Verification

| Check | Result |
|---|---|
| All 3 frontend endpoint URLs + payloads match the 3 backend PUT routes | ✅ |
| `useSelector((state) => state.updatePassword)` matches store key | ✅ |
| Profile `UpdatePassword.jsx` — thunk signature unchanged, additive state only, no regression | ✅ |
| `verifyOtp` backend clears `forgot_password_otp` fields on success → `resetPassword` works | ✅ |
| All 3 frontend files compile clean (esbuild); `userController.js` passes `node --check` | ✅ |
| Backend diff: single surgical block in `forgotPassword`, nothing else changed | ✅ |
| All files disjoint from open PRs #51 and #96 — no conflict risk | ✅ |
| No new npm dependencies | ✅ |
| 4 files · 334 net insertions · 88 deletions | ✅ |

---

## Checklist
- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] OTP request → OTP verify → password reset → success redirect all functional
- [x] Validation and error messages at every step
- [x] Email-send failure reported to user instead of silently dropped
- [x] Direct URL access to reset page guarded
- [x] Profile update password page unaffected