### PR TITLE
fix(discovery): make similar products category-aware and exclude current product (Closes #61)

### DIFF
--- a/client/src/pages/products/SingleProduct.jsx
+++ b/client/src/pages/products/SingleProduct.jsx
@@ -108,7 +108,13 @@ const ProductDetails = ({ products }) => {
 
   useEffect(() => {
     if (product?.category) {
-      dispatch(getSimilarProducts(product.category));
+      dispatch(
+        getSimilarProducts({
+          category: product.category,
+          subcategory: product.subcategory,
+          exclude: product._id,
+        })
+      );
       dispatch(getTrendingProducts(8));
       dispatch(getFrequentlyBoughtTogether(product._id));
     }
@@ -143,8 +149,17 @@ const ProductDetails = ({ products }) => {
 
   useEffect(() => {
     const combined = [...(similarProducts || []), ...(products || [])];
-    setRandomSimilar(combined.sort(() => Math.random() - 0.5).slice(0, 6));
-  }, [similarProducts, products]);
+    // Exclude the product currently being viewed and de-duplicate by id so the
+    // "You Might Also Like" grid never shows the same product twice or itself.
+    const seen = new Set();
+    const unique = combined.filter((item) => {
+      if (!item || !item._id || item._id === product?._id) return false;
+      if (seen.has(item._id)) return false;
+      seen.add(item._id);
+      return true;
+    });
+    setRandomSimilar(unique.sort(() => Math.random() - 0.5).slice(0, 6));
+  }, [similarProducts, products, product]);
 
   useEffect(() => {
     if (product) {

--- a/client/src/store/product-slice/productDetails.js
+++ b/client/src/store/product-slice/productDetails.js
@@ -79,9 +79,28 @@ export const deleteReview = createAsyncThunk(
 
 export const getSimilarProducts = createAsyncThunk(
   "product/getSimilar",
-  async (_, { rejectWithValue }) => {
+  async (params = {}, { rejectWithValue }) => {
     try {
-      const response = await axiosInstance.get("/api/product/similar");
+      // Accept either a category string (legacy callers) or an options object,
+      // and forward the criteria as query params so results are actually
+      // category/subcategory-relevant and exclude the current product.
+      const query =
+        typeof params === "string"
+          ? { category: params }
+          : {
+              ...(params.category ? { category: params.category } : {}),
+              ...(params.subcategory
+                ? { subcategory: params.subcategory }
+                : {}),
+              ...(params.coloroptions
+                ? { coloroptions: params.coloroptions }
+                : {}),
+              ...(params.exclude ? { exclude: params.exclude } : {}),
+            };
+
+      const response = await axiosInstance.get("/api/product/similar", {
+        params: query,
+      });
       return response.data.similarProducts;
     } catch (error) {
       return rejectWithValue(

--- a/server/controllers/productController.js
+++ b/server/controllers/productController.js
@@ -414,7 +414,7 @@ export const getProductByFilter = catchAsyncErrors(async (req, res) => {
 
 export const getSimilarProducts = catchAsyncErrors(async (req, res) => {
   try {
-    const { category, subcategory, color, coloroptions } = req.query;
+    const { category, subcategory, color, coloroptions, exclude } = req.query;
 
     let filter = { $or: [] };
 
@@ -425,6 +425,9 @@ export const getSimilarProducts = catchAsyncErrors(async (req, res) => {
       filter.$or.push({ coloroptions: { $in: coloroptions.split(",") } });
 
     if (filter.$or.length === 0) filter = {};
+
+    // Never recommend the product the user is already viewing.
+    if (exclude) filter._id = { $ne: exclude };
 
     const similarProducts = await ProductModel.find(filter).limit(10);
 


### PR DESCRIPTION
## Summary
Improves the product-discovery experience on the product details page. The recently-viewed and recommendation infrastructure already exists and works well; this PR fixes the one genuine defect that undermined it — "You Might Also Like" was not actually category-relevant — and removes self/duplicate entries from the grid.

Closes #61

## What already worked (left unchanged)
The product page already provides a solid discovery experience, all of which is preserved:
- **Recently Viewed** — tracked in `localStorage`, capped at 8, de-duplicated, and excludes the current product
- **Frequently Bought Together** and **Trending Now** sections
- Cross-navigation via product cards throughout

## The bug this fixes
`SingleProduct.jsx` calls `dispatch(getSimilarProducts(product.category))`, but the `getSimilarProducts` thunk ignored its argument — its signature was `async (_, ...)` and it requested `/api/product/similar` with **no query parameters**. The backend `getSimilarProducts` controller *does* support `category`/`subcategory`/`coloroptions` filters, but since nothing was sent, the filter fell back to `{}` and returned arbitrary products. As a result, the "You Might Also Like" section was not category-relevant, and because the current product was never excluded, the product being viewed (and duplicates) could appear in its own recommendations.

## Changes — 3 files

### `client/src/store/product-slice/productDetails.js`
- `getSimilarProducts` now accepts either a category string (backward compatible) or an options object, and forwards `category`, `subcategory`, `coloroptions`, and `exclude` as query parameters so the backend can actually filter.

### `server/controllers/productController.js`
- `getSimilarProducts` now reads an `exclude` query param and adds `_id: { $ne: exclude }` to the filter, so the product currently being viewed is never recommended. (Existing category/subcategory/color filtering untouched.)

### `client/src/pages/products/SingleProduct.jsx`
- Passes `{ category, subcategory, exclude: product._id }` to `getSimilarProducts` so results are category/subcategory-relevant.
- The "You Might Also Like" grid now excludes the current product and de-duplicates by `_id` before shuffling, so no card repeats or shows the product itself.

## Verification
| Check | Result |
|---|---|
| Thunk query params ↔ backend `req.query` fields align (`category`, `subcategory`, `coloroptions`, `exclude`) | ✅ |
| Only caller of `getSimilarProducts` updated; legacy string form still supported | ✅ |
| All 3 files compile (esbuild / node --check) | ✅ |
| Additive/surgical — only the modified lines changed, no features removed | ✅ |
| No new dependencies; recently-viewed / trending / FBT sections untouched | ✅ |
| Disjoint from open PRs #51, #96, #55, #98 — no conflicts | ✅ |

## Checklist
- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] Similar products are now genuinely category-based
- [x] Current product no longer recommended to itself; no duplicates
- [x] Existing discovery sections preserved