### PR TITLE
feat(ux): add consistent accessible empty states across user pages (Closes #60)

### DIFF
--- a/client/src/pages/components/EmptyState.jsx
+++ b/client/src/pages/components/EmptyState.jsx
@@ -1,0 +1,68 @@
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+
+/**
+ * A consistent, accessible empty-state block used across user-facing pages
+ * (cart, wishlist, orders, addresses). Renders an icon, a title, optional
+ * guidance text, and an optional call-to-action — either a router Link
+ * (`actionTo`) or a button (`onAction`).
+ */
+const EmptyState = ({
+  icon: Icon,
+  title,
+  message,
+  actionLabel,
+  actionTo,
+  onAction,
+}) => {
+  const actionClasses =
+    "inline-flex items-center justify-center px-6 py-2.5 rounded-full bg-yellow-500 hover:bg-yellow-600 dark:bg-red-600 dark:hover:bg-red-700 text-white font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-yellow-400 dark:focus:ring-red-500";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-col items-center justify-center text-center py-16 px-4"
+    >
+      {Icon ? (
+        <div className="w-20 h-20 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center mb-5">
+          <Icon
+            className="w-10 h-10 text-gray-400 dark:text-gray-300"
+            aria-hidden="true"
+          />
+        </div>
+      ) : null}
+
+      <h2 className="text-xl sm:text-2xl font-semibold text-gray-800 dark:text-gray-100 mb-2">
+        {title}
+      </h2>
+
+      {message ? (
+        <p className="text-sm sm:text-base text-gray-500 dark:text-gray-400 max-w-md mb-6">
+          {message}
+        </p>
+      ) : null}
+
+      {actionLabel && actionTo ? (
+        <Link to={actionTo} className={actionClasses}>
+          {actionLabel}
+        </Link>
+      ) : actionLabel && onAction ? (
+        <button type="button" onClick={onAction} className={actionClasses}>
+          {actionLabel}
+        </button>
+      ) : null}
+    </div>
+  );
+};
+
+EmptyState.propTypes = {
+  icon: PropTypes.elementType,
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string,
+  actionLabel: PropTypes.string,
+  actionTo: PropTypes.string,
+  onAction: PropTypes.func,
+};
+
+export default EmptyState;

--- a/client/src/pages/my-profile/MyOrders.jsx
+++ b/client/src/pages/my-profile/MyOrders.jsx
@@ -14,6 +14,8 @@ import {
 } from "@mui/material";
 import { Link } from "react-router-dom";
 import { myOrders } from "@/store/order-slice/order";
+import EmptyState from "../components/EmptyState";
+import { Package } from "lucide-react";
 import { jsPDF } from "jspdf";
 
 const MyOrders = () => {
@@ -351,9 +353,13 @@ const MyOrders = () => {
               {typeof error === "string" ? error : "No Orders Available"}
             </Alert>
           ) : filteredProducts.length === 0 ? (
-            <Alert severity="info" className="text-sm sm:text-base">
-              No orders found
-            </Alert>
+            <EmptyState
+              icon={Package}
+              title="No orders yet"
+              message="When you place an order it will appear here, so you can track and revisit it anytime."
+              actionLabel="Start Shopping"
+              actionTo="/products"
+            />
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-2 sm:gap-4">
               <AnimatePresence>

--- a/client/src/pages/my-profile/SavedAddress.jsx
+++ b/client/src/pages/my-profile/SavedAddress.jsx
@@ -11,6 +11,7 @@ import { toast } from "react-toastify";
 import { motion, AnimatePresence } from "framer-motion";
 import { Country, State, City } from "country-state-city";
 import MetaData from "../extras/MetaData";
+import EmptyState from "../components/EmptyState";
 
 const SavedAddress = () => {
   const dispatch = useDispatch();
@@ -231,7 +232,13 @@ const SavedAddress = () => {
               </motion.div>
             ))
           ) : (
-            <p className="text-center text-gray-500">No addresses found.</p>
+            <EmptyState
+              icon={MapPin}
+              title="No addresses saved"
+              message="Add a delivery address to make checkout faster next time."
+              actionLabel="Add Address"
+              onAction={() => setIsAdding(true)}
+            />
           )}
         </div>
       </div>

--- a/client/src/pages/orders/Cart.jsx
+++ b/client/src/pages/orders/Cart.jsx
@@ -11,8 +11,10 @@ import {
 import MetaData from "../extras/MetaData";
 import CartSkeleton from "../components/skeletons/CartSkeleton";
 import RecommendationSection from "../components/RecommendationSection";
+import EmptyState from "../components/EmptyState";
+import { ShoppingCart } from "lucide-react";
 import { getTrendingProducts } from "@/store/product-slice/productDetails";
-import { Button, IconButton } from "@mui/material";
+import { IconButton } from "@mui/material";
 import { ShoppingCartCheckout } from "@mui/icons-material";
 
 const Cart = () => {
@@ -97,18 +99,13 @@ const Cart = () => {
         {error && <p className="text-red-500 text-center py-10">{error}</p>}
 
         {cartItems.length === 0 ? (
-          <motion.div
-            className="text-center py-10 dark:text-gray-300"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-          >
-            <p className="text-lg mb-4">Your cart is empty.</p>
-            <Link to="/products">
-              <Button variant="contained" color="primary">
-                Continue Shopping
-              </Button>
-            </Link>
-          </motion.div>
+          <EmptyState
+            icon={ShoppingCart}
+            title="Your cart is empty"
+            message="Looks like you haven't added anything yet. Find something you love and add it to your cart."
+            actionLabel="Continue Shopping"
+            actionTo="/products"
+          />
         ) : (
           <div className="space-y-6">
             <AnimatePresence>

--- a/client/src/pages/orders/Wishlist.jsx
+++ b/client/src/pages/orders/Wishlist.jsx
@@ -10,6 +10,8 @@ import {
 import { Link, useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import WishlistSkeleton from "../components/skeletons/WishlistSkeleton";
+import EmptyState from "../components/EmptyState";
+import { Heart } from "lucide-react";
 
 const WishlistPage = () => {
   const dispatch = useDispatch();
@@ -50,14 +52,15 @@ const WishlistPage = () => {
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
         <AnimatePresence>
           {WishListItems.length === 0 ? (
-            <motion.p
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="col-span-full text-center text-gray-600"
-            >
-              Your wishlist is empty.
-            </motion.p>
+            <div className="col-span-full">
+              <EmptyState
+                icon={Heart}
+                title="Your wishlist is empty"
+                message="Save the items you love and they'll appear here. Start exploring our collection."
+                actionLabel="Browse Products"
+                actionTo="/products"
+              />
+            </div>
           ) : (
             WishListItems.map((item) => (
               <motion.div


### PR DESCRIPTION
## Summary
Replaces the bare single-line empty states on the key user-facing pages with a consistent, accessible, dark-mode-aware empty-state pattern that gives users clear guidance and an obvious next action.

Closes #60

## Problem
The Wishlist, Cart, Orders, and Saved Address pages each had a minimal text-only empty state — e.g. "Your wishlist is empty.", "No orders found", "No addresses found." — with no guidance, no icon, no call to action, and inconsistent styling between pages.

## Approach
Introduces one reusable `EmptyState` component and uses it on all four pages, so the empty experience is visually consistent everywhere (a goal called out in the issue) and easy to reuse on future pages.

## Changes — 5 files

### `client/src/pages/components/EmptyState.jsx` (new)
A small, reusable empty-state block:
- Icon in a soft circle, a title, optional guidance text, and an optional CTA
- CTA can be a router `Link` (`actionTo`) **or** a button (`onAction`) — needed because some "add" actions are routes and others (addresses) open a modal
- Accessible: `role="status"`, `aria-live="polite"`, and `aria-hidden` on the decorative icon; CTA has visible focus ring
- Fully dark-mode aware, matching the existing yellow/red accent system

### `client/src/pages/orders/Wishlist.jsx`
- Empty wishlist now shows a heart icon, guidance, and a **Browse Products** CTA → `/products`

### `client/src/pages/orders/Cart.jsx`
- Empty cart now uses the shared component (cart icon + guidance + **Continue Shopping** CTA → `/products`), replacing the old inline text/button
- Removed the now-unused MUI `Button` import

### `client/src/pages/my-profile/MyOrders.jsx`
- Empty orders now shows a package icon, guidance, and a **Start Shopping** CTA → `/products` (replaces the plain info Alert)

### `client/src/pages/my-profile/SavedAddress.jsx`
- Empty address list now shows a map-pin icon, guidance, and an **Add Address** CTA that opens the existing add-address modal (`onAction` → `setIsAdding(true)`)

## Verification
| Check | Result |
|---|---|
| All 5 files compile clean (esbuild) | ✅ |
| Each page's edit is surgical — only the empty block + imports changed | ✅ |
| `EmptyState` import path resolves from both `orders/` and `my-profile/` | ✅ |
| No unused imports introduced (Cart's orphaned `Button` removed; `Alert`/`Link`/`MapPin`/`Button` elsewhere still used) | ✅ |
| CTA correctly uses Link (cart/wishlist/orders) vs onClick (addresses modal) | ✅ |
| Accessible (role/aria-live/aria-hidden/focus ring); dark-mode consistent | ✅ |
| No new dependencies; disjoint from open PRs #51/#96/#55/#98/#99 | ✅ |

## Checklist
- [x] Assigned before opening this PR
- [x] Branch based on `elusoc`
- [x] Empty states give clear guidance + an obvious action on every page
- [x] Visually consistent across all four pages
- [x] Accessible empty-state messaging