### PR TITLE
fix(ux): show only EmptyState on empty cart/wishlist/orders (Closes #103)

### DIFF
--- a/client/src/store/add-to-cart/addToCart.js
+++ b/client/src/store/add-to-cart/addToCart.js
@@ -39,6 +39,11 @@ export const getCartItems = createAsyncThunk(
       });
       return response.data;
     } catch (error) {
+      // An empty cart is returned by the API as a 404. Treat it as an
+      // empty (non-error) result so the page shows only the EmptyState.
+      if (error.response?.status === 404) {
+        return { data: [], error: false, success: true };
+      }
       return rejectWithValue(
         error.response?.data?.message || "Failed to fetch cart items"
       );
@@ -152,6 +157,7 @@ const cartSlice = createSlice({
 
       .addCase(getCartItems.pending, (state) => {
         state.loading = true;
+        state.error = null;
       })
       .addCase(getCartItems.fulfilled, (state, action) => {
         state.loading = false;

--- a/client/src/store/add-to-wishList/addToWishList.js
+++ b/client/src/store/add-to-wishList/addToWishList.js
@@ -38,6 +38,11 @@ export const getWishListItems = createAsyncThunk(
       });
       return response.data;
     } catch (error) {
+      // An empty wishlist is returned by the API as a 404. Treat it as an
+      // empty (non-error) result so the page shows only the EmptyState.
+      if (error.response?.status === 404) {
+        return { data: [], error: false, success: true };
+      }
       return rejectWithValue(
         error.response?.data?.message || "Failed to fetch WishList items"
       );
@@ -117,6 +122,7 @@ const WishListSlice = createSlice({
 
       .addCase(getWishListItems.pending, (state) => {
         state.loading = true;
+        state.error = null;
       })
       .addCase(getWishListItems.fulfilled, (state, action) => {
         state.loading = false;

--- a/client/src/store/order-slice/order.js
+++ b/client/src/store/order-slice/order.js
@@ -74,6 +74,11 @@ export const myOrders = createAsyncThunk(
       });
       return response.data;
     } catch (error) {
+      // No orders for this user comes back as a 404. Treat it as an empty
+      // (non-error) result so the page shows only the EmptyState.
+      if (error.response?.status === 404) {
+        return { orders: [] };
+      }
       return rejectWithValue(error.response.data);
     }
   }
@@ -154,6 +159,7 @@ export const orderSlice = createSlice({
       })
       .addCase(myOrders.pending, (state) => {
         state.loading = true;
+        state.error = null;
       })
       .addCase(myOrders.fulfilled, (state, action) => {
         state.loading = false;


### PR DESCRIPTION
## Summary
Fixes the duplicate empty-state messaging on the Wishlist, Cart, and Orders
pages (#103). Only the reusable EmptyState component now renders when a list
is empty.

## Root cause
The backend returns an empty cart/wishlist/orders as a **404 with a message**
(`cartController.js`, `wishListController.js`, `orderController.js`). Each redux
slice rejects on that 404 and stores the message as `error`, which the pages
then render — as red text *alongside* EmptyState (Cart/Wishlist), or as an
error Alert that hides EmptyState (Orders). The legacy text was coming from the
API response, not from hardcoded blocks in the page components.

## Fix
The three get-thunks now treat an empty-list 404 as an empty, **non-error**
result, so `error` stays null on an empty list and only EmptyState renders.
Genuine errors (500 / 401 / network) are unaffected and still display.

- `getCartItems` / `getWishListItems`: empty-404 → `{ data: [] }`
- `myOrders`: empty-404 → `{ orders: [] }`
- Each `*.pending` reducer resets `error` so stale errors can't linger

No changes to `Cart.jsx`, `Wishlist.jsx`, or `MyOrders.jsx` — they already render
correctly given clean data, which preserves all of PR #100's styling,
accessibility, and CTA behavior.

## Verification
- `npm run build` ✓ (22.88s); ESLint clean; `node --check` on all three slices
- Empty cart/wishlist/orders now renders only the EmptyState; non-empty lists
  and real errors behave as before

_Investigated and implemented and reviewed before submission._